### PR TITLE
[WFCORE-613] Add a dependency on org.jboss.threads to the Elytron module

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -36,6 +36,7 @@
     <dependencies>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
+        <module name="org.jboss.threads"/>
         <module name="javax.api" />
         <module name="sun.jdk"/>
         <module name="org.wildfly.common"/>


### PR DESCRIPTION
This is needed for https://github.com/wildfly-security/wildfly-elytron/pull/458.
