### PR TITLE
Fix hang in DomainDeploymentOverlayTestCase

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -80,7 +80,11 @@ public class CLIModelControllerClient extends AbstractModelControllerClient
         // Allow the core threads to time out as well
         executorService.allowCoreThreadTimeOut(true);
 
-        endpoint = Endpoint.getCurrent();
+        try {
+            endpoint = Endpoint.builder().setEndpointName("cli-client").build();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create remoting endpoint");
+        }
 
         CliShutdownHook.add(new CliShutdownHook.Handler() {
             @Override

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionManager.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionManager.java
@@ -116,7 +116,7 @@ public final class ProtocolConnectionManager {
                 connectTask.shutdown();
             }
         }
-        StreamUtils.safeClose(connection);
+        connection.closeAsync();
     }
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainControllerClientConfig.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainControllerClientConfig.java
@@ -110,7 +110,7 @@ public class DomainControllerClientConfig implements Closeable {
     }
 
     static DomainControllerClientConfig create(final ExecutorService executorService, boolean destroyExecutor) throws IOException {
-        final Endpoint endpoint = Endpoint.getCurrent();
+        final Endpoint endpoint = Endpoint.builder().setEndpointName(ENDPOINT_NAME).build();
 
         return new DomainControllerClientConfig(endpoint, executorService, destroyExecutor);
     }


### PR DESCRIPTION
These changes fix the hang in DomainDeploymentOverlayTestCase. However, I'm now seeing the following intermittent failure in DomainDeploymentOverlayTestCase:

```
testSimpleOverrideWithRedeployAffected(org.jboss.as.test.integration.domain.management.cli.DomainDeploymentOverlayTestCase)  Time elapsed: 5.309 sec  <<< ERROR!
org.jboss.as.cli.CommandLineException: The controller is not available at 127.0.0.1:9999
	at org.jboss.as.protocol.ProtocolConnectionUtils.connectSync(ProtocolConnectionUtils.java:131)
	at org.jboss.as.protocol.ProtocolConnectionManager$EstablishingConnection.connect(ProtocolConnectionManager.java:257)
	at org.jboss.as.protocol.ProtocolConnectionManager.connect(ProtocolConnectionManager.java:70)
	at org.jboss.as.protocol.mgmt.ManagementClientChannelStrategy$Establishing.getChannel(ManagementClientChannelStrategy.java:162)
	at org.jboss.as.cli.impl.CLIModelControllerClient.getOrCreateChannel(CLIModelControllerClient.java:172)
	at org.jboss.as.cli.impl.CLIModelControllerClient$3.getChannel(CLIModelControllerClient.java:132)
	at org.jboss.as.protocol.mgmt.ManagementChannelHandler.executeRequest(ManagementChannelHandler.java:135)
	at org.jboss.as.protocol.mgmt.ManagementChannelHandler.executeRequest(ManagementChannelHandler.java:110)
	at org.jboss.as.controller.client.impl.AbstractModelControllerClient.executeRequest(AbstractModelControllerClient.java:263)
	at org.jboss.as.controller.client.impl.AbstractModelControllerClient.execute(AbstractModelControllerClient.java:168)
	at org.jboss.as.controller.client.impl.AbstractModelControllerClient.executeForResult(AbstractModelControllerClient.java:147)
	at org.jboss.as.controller.client.impl.AbstractModelControllerClient.execute(AbstractModelControllerClient.java:75)
	at org.jboss.as.cli.impl.CommandContextImpl.tryConnection(CommandContextImpl.java:1296)
	at org.jboss.as.cli.impl.CommandContextImpl.connectController(CommandContextImpl.java:1142)
	at org.jboss.as.cli.impl.CommandContextImpl.connectController(CommandContextImpl.java:1181)
	at org.jboss.as.test.integration.domain.management.cli.DomainDeploymentOverlayTestCase.setUp(DomainDeploymentOverlayTestCase.java:148)
```