### PR TITLE
[WFCORE-2156] CredentialReference marshalling fix

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/security/CredentialReference.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/CredentialReference.java
@@ -282,16 +282,19 @@ public final class CredentialReference implements Destroyable {
     private static AttributeMarshaller credentialReferenceAttributeMarshaller() {
         return new AttributeMarshaller() {
             @Override
-            public void marshallAsElement(AttributeDefinition attribute, ModelNode credentialReferenceModelNode, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
-                writer.writeStartElement(attribute.getXmlName());
-                if (credentialReferenceModelNode.hasDefined(clearTextAttribute.getName())) {
-                    clearTextAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
-                } else {
-                    credentialStoreAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
-                    credentialAliasAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
-                    credentialTypeAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+            public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+                ModelNode credentialReferenceModelNode = resourceModel.get(CredentialReference.CREDENTIAL_REFERENCE);
+                if (credentialReferenceModelNode.isDefined()) {
+                    writer.writeStartElement(attribute.getXmlName());
+                    if (credentialReferenceModelNode.hasDefined(clearTextAttribute.getName())) {
+                        clearTextAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+                    } else {
+                        credentialStoreAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+                        credentialAliasAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+                        credentialTypeAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+                    }
+                    writer.writeEndElement();
                 }
-                writer.writeEndElement();
             }
 
             @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2156

Related elytron subsystem change: https://github.com/wildfly-security/elytron-subsystem/pull/353

To ensure CredentialReference attribute can be marshalled using standard PersistentResourceXMLDescription marshaller. (instead of custom subsystem parser)