### PR TITLE
[WFCORE-1802] Leave registering wildfly-openssl to the Elytron subsystem.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -23,7 +23,6 @@
 package org.jboss.as.domain.management.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
@@ -1234,9 +1233,9 @@ public interface DomainManagementLogger extends BasicLogger {
     @Message(id = 135, value = "The resource %s wasn't working properly and has been removed.")
     String removedBrokenResource(final String address);
 
-    @LogMessage(level = INFO)
-    @Message(id = 136, value = "Registered OpenSSL provider")
-    void registeredOpenSSLProvider();
+    //@LogMessage(level = INFO)
+    //@Message(id = 136, value = "Registered OpenSSL provider")
+    //void registeredOpenSSLProvider();
 
     // Was WFLYRMT-13
     @Message(id = 137, value = "Unable to create tmp dir for auth tokens as file already exists.")

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmResourceDefinition.java
@@ -37,10 +37,8 @@ import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.wildfly.openssl.OpenSSLProvider;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for a management security realm resource.
@@ -49,17 +47,6 @@ import org.wildfly.openssl.OpenSSLProvider;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class SecurityRealmResourceDefinition extends SimpleResourceDefinition {
-
-    static {
-        //register the Openssl Provider, if possible
-        //not really sure if this is the best place for it
-        try {
-            OpenSSLProvider.register();
-            DomainManagementLogger.ROOT_LOGGER.registeredOpenSSLProvider();
-        } catch (Throwable t){
-            DomainManagementLogger.ROOT_LOGGER.debugf(t, "Failed to register OpenSSL provider");
-        }
-    }
 
     public static final SecurityRealmResourceDefinition INSTANCE = new SecurityRealmResourceDefinition();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
@@ -21,6 +21,7 @@ package org.wildfly.extension.elytron;
 import java.security.KeyStore;
 import java.security.Policy;
 import java.security.Provider;
+import java.util.function.Consumer;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -28,6 +29,7 @@ import javax.net.ssl.TrustManager;
 import javax.security.sasl.SaslServerFactory;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.msc.service.ServiceBuilder;
 import org.wildfly.extension.elytron.capabilities.CredentialSecurityFactory;
 import org.wildfly.extension.elytron.capabilities.DirContextSupplier;
 import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
@@ -81,8 +83,8 @@ class Capabilities {
 
     static final String ELYTRON_CAPABILITY = CAPABILITY_BASE + "elytron";
 
-    static final RuntimeCapability<Void> ELYTRON_RUNTIME_CAPABILITY = RuntimeCapability
-            .Builder.of(ELYTRON_CAPABILITY, false)
+    static final RuntimeCapability<Consumer<ServiceBuilder>> ELYTRON_RUNTIME_CAPABILITY = RuntimeCapability
+            .Builder.of(ELYTRON_CAPABILITY, (Consumer<ServiceBuilder>) ElytronDefinition::commonDependencies)
             .build();
 
     static final String HTTP_AUTHENTICATION_FACTORY_CAPABILITY = CAPABILITY_BASE + "http-authentication-factory";

--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -19,7 +19,7 @@
 
 <config default-supplement="standalone" >
     <extension-module>org.wildfly.extension.elytron</extension-module>
-    <subsystem xmlns="urn:wildfly:elytron:1.0" initial-providers="combined-providers">
+    <subsystem xmlns="urn:wildfly:elytron:1.0" final-providers="combined-providers">
         <providers>
             <provider-loader name="elytron" module="org.wildfly.security.elytron" />
             <provider-loader name="openssl" module="org.wildfly.openssl" />


### PR DESCRIPTION
The legacy security realms use the runtime API of the org.wildfly.security.elytron capability to add dependencies on the Elytron core services if the capability is available.

Due to a couple of test failures in WildFly the providers are temporarily registered last.  Once we can address the test failures this should be reverted so we can use OpenSSL by default when available.