### PR TITLE
Elytron LdapTestCase fix - working directory sharing

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -62,7 +62,7 @@ class TestEnvironment extends AdditionalInitialization {
         try {
             LdapService.builder()
                     .setWorkingDir(new File("./target/apache-ds/working1"))
-                    .createDirectoryService("Test Service")
+                    .createDirectoryService("TestService1")
                     .addPartition("Elytron", "dc=elytron,dc=wildfly,dc=org", 5, "uid")
                     .importLdif(TestEnvironment.class.getResourceAsStream("ldap-schemas.ldif"))
                     .importLdif(TestEnvironment.class.getResourceAsStream("ldap-data.ldif"))
@@ -70,7 +70,7 @@ class TestEnvironment extends AdditionalInitialization {
                     .start();
             LdapService.builder()
                     .setWorkingDir(new File("./target/apache-ds/working2"))
-                    .createDirectoryService("Test Service")
+                    .createDirectoryService("TestService2")
                     .addPartition("Elytron", "dc=elytron,dc=wildfly,dc=org", 5, "uid")
                     .importLdif(TestEnvironment.class.getResourceAsStream("ldap-schemas.ldif"))
                     .importLdif(TestEnvironment.class.getResourceAsStream("ldap-referred.ldif"))


### PR DESCRIPTION
Fix of test, which makes problems on Windows:

```
12:11:33,960 WARN (main) [org.apache.directory.server.core.factory.DefaultDirectoryServiceFactory] <DefaultDirectoryServiceFactory.java:151> 
couldn't delete the instance directory before initializing the DirectoryService: java.io.IOException: 
Unable to delete file: C:\BuildAgent\work\7a75e8541221a956\core\elytron\target\server-work-Test Service\partitions\system\master.lg
```