### PR TITLE
[WFCORE-2461] Credential-store attribute relative-to doesn't reference path as required

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1184,7 +1184,6 @@ elytron.credential-store.providers=The name of the providers defined within the 
 elytron.credential-store.other-providers=The name of the providers defined within the subsystem to obtain the Providers to search for the one that can create the required JCA objects within credential store. This is valid only for key-store based CredentialStore. If this is not specified then the global list of Providers is used instead.
 elytron.credential-store.provider-name=The name of the provider to use to instantiate the CredentialStoreSpi. If the provider is not specified then the first provider found that can create an instance of the specified 'type' will be used.
 elytron.credential-store.uri=The URI for credential store definition.
-elytron.credential-store.path=Base directory for credential store file storage.
 elytron.credential-store.relative-to=A reference to a previously defined path that the file name is relative to.
 elytron.credential-store.alias=Alias of sensitive information (e.g. password) to be referenced later in configuration.
 elytron.credential-store.alias.add=Add alias to the credential store.


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-2461
JBEAP: https://issues.jboss.org/browse/JBEAP-8755

credential-store doesn't define "path" so this is not relevant. We have
description for property "elytron.credential-store.path" which should be
removed.