### PR TITLE
[WFLY-8131]:  Aliases in credential stores should be case insensitive.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreAliasDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreAliasDefinition.java
@@ -18,7 +18,7 @@
 
 package org.wildfly.extension.elytron;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.wildfly.extension.elytron.CredentialStoreResourceDefinition.CASE_SENSITIVE;
 import static org.wildfly.extension.elytron.CredentialStoreResourceDefinition.CREDENTIAL_STORE_UTIL;
 import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -48,9 +47,9 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.credential.store.CredentialStoreException;
@@ -107,7 +106,6 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
         );
     }
 
-
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
@@ -121,60 +119,6 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerReadWriteAttribute(ENTRY_TYPE, null, new WriteAttributeHandler());
     }
 
-    static String alias(ModelNode operation) {
-        String aliasName = null;
-        PathAddress pa = PathAddress.pathAddress(operation.require(OP_ADDR));
-        for (int i = pa.size() - 1; i > 0; i--) {
-            PathElement pe = pa.getElement(i);
-            if (ElytronDescriptionConstants.ALIAS.equals(pe.getKey())) {
-                aliasName = pe.getValue();
-                break;
-            }
-        }
-
-        if (aliasName == null) {
-            throw ROOT_LOGGER.operationAddressMissingKey(ElytronDescriptionConstants.ALIAS);
-        }
-
-        return aliasName.toLowerCase(Locale.ROOT);
-    }
-
-    private static void transformOperationAddress(final ModelNode operation) {
-        Property alias = propertyAliasFromOperation(operation);
-        if (alias != null)
-        {
-            String newAlias = alias.getValue().asString().toLowerCase(Locale.ROOT);
-            alias.getValue().set(newAlias);
-        }
-    }
-
-    private static Property propertyAliasFromOperation(final ModelNode operation) {
-        ModelNode address = operation.get(ModelDescriptionConstants.OP_ADDR);
-        List<Property> list = address.asPropertyList();
-        Property alias = null;
-        for (Property p: list) {
-            if (ElytronDescriptionConstants.ALIAS.equals(p.getName())) {
-                alias = p;
-                break;
-            }
-        }
-        return alias;
-    }
-
-    private static boolean sameAlias(final OperationContext context, final ModelNode operation) {
-        PathElement contextAlias = context.getCurrentAddress().getLastElement();
-        Property operationAlias = propertyAliasFromOperation(operation);
-        boolean outcome = false;
-        if (contextAlias != null && operationAlias != null)
-        {
-            outcome = contextAlias.getValue().equals(operationAlias.getValue().asString());
-        } else {
-            outcome = contextAlias == null && operationAlias == null ? true : false;
-        }
-
-        return  outcome;
-    }
-
     private static class AddHandler extends BaseAddHandler {
 
         AddHandler() {
@@ -183,7 +127,7 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
 
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-            String alias = alias(operation);
+            String alias = context.getCurrentAddressValue();
             String secretValue = asStringIfDefined(context, SECRET_VALUE, resource.getModel());
             String entryType = asStringIfDefined(context, ENTRY_TYPE, resource.getModel());
             ServiceName credentialStoreServiceName = CREDENTIAL_STORE_UTIL.serviceName(operation);
@@ -215,19 +159,14 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
          */
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            transformOperationAddress(operation);
+            if (!CASE_SENSITIVE.resolveModelAttribute(context, context.readResourceFromRoot(context.getCurrentAddress().getParent(), false).getModel()).asBoolean()) {
+                String aliasName = context.getCurrentAddressValue();
+                if (!aliasName.equals(aliasName.toLowerCase(Locale.ROOT))) {
+                    throw ElytronSubsystemMessages.ROOT_LOGGER.invalidAliasName(aliasName, context.getCurrentAddress().getParent().getLastElement().getValue());
+                }
+            }
             super.execute(context, operation);
         }
-
-        @Override
-        protected Resource createResource(OperationContext context, ModelNode operation) {
-            Resource resource = Resource.Factory.create(true);
-            if (sameAlias(context, operation)) {
-                context.addResource(PathAddress.EMPTY_ADDRESS, resource);
-            }
-            return resource;
-        }
-
     }
 
     private static class RemoveHandler extends CredentialStoreResourceDefinition.CredentialStoreRuntimeOnlyHandler {
@@ -238,10 +177,9 @@ class CredentialStoreAliasDefinition extends SimpleResourceDefinition {
 
         @Override
         protected void performRuntime(ModelNode result, OperationContext context, ModelNode operation, CredentialStoreService credentialStoreService) throws OperationFailedException {
-            String alias = alias(operation);
             try {
                 CredentialStore credentialStore = credentialStoreService.getValue();
-                credentialStore.remove(alias, PasswordCredential.class);
+                credentialStore.remove(context.getCurrentAddressValue(), PasswordCredential.class);
                 credentialStore.flush();
             } catch (CredentialStoreException e) {
                 throw new OperationFailedException(e);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreParser.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CASE_SENSITIVE;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CREDENTIAL_STORE;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CREDENTIAL_STORES;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.NAME;
@@ -108,6 +109,9 @@ class CredentialStoreParser {
                     case RELATIVE_TO:
                         CredentialStoreResourceDefinition.RELATIVE_TO.parseAndSetParameter(value, addCredentialStore, reader);
                         break;
+                    case CASE_SENSITIVE:
+                        CredentialStoreResourceDefinition.CASE_SENSITIVE.parseAndSetParameter(value, addCredentialStore, reader);
+                        break;
                     default:
                         throw unexpectedAttribute(reader, i);
                 }
@@ -151,6 +155,7 @@ class CredentialStoreParser {
                 CredentialStoreResourceDefinition.PROVIDERS.marshallAsAttribute(credentialStoreModelNode, writer);
                 CredentialStoreResourceDefinition.OTHER_PROVIDERS.marshallAsAttribute(credentialStoreModelNode, writer);
                 CredentialStoreResourceDefinition.RELATIVE_TO.marshallAsAttribute(credentialStoreModelNode, writer);
+                CredentialStoreResourceDefinition.CASE_SENSITIVE.marshallAsAttribute(credentialStoreModelNode, writer);
                 CredentialStoreResourceDefinition.URI.marshallAsElement(credentialStoreModelNode, writer);
                 CredentialStoreResourceDefinition.CREDENTIAL_REFERENCE.marshallAsElement(credentialStoreModelNode, writer);
                 writer.writeEndElement();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResource.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResource.java
@@ -20,10 +20,8 @@ package org.wildfly.extension.elytron;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.logging.ControllerLogger;
@@ -70,13 +68,12 @@ class CredentialStoreResource extends DelegatingResource {
         if (ElytronDescriptionConstants.ALIAS.equals(element.getKey())) {
             try {
                 CredentialStore credentialStore = credentialStoreServiceController != null ? credentialStoreServiceController.getValue() : null;
-                if (credentialStore != null && (credentialStore.getAliases().contains(toLower(element.getValue())))) {
+                if (credentialStore != null && (credentialStore.getAliases().contains(element.getValue()))) {
                     return true;
                 }
             } catch (CredentialStoreException e) {
                 ElytronSubsystemMessages.ROOT_LOGGER.credentialStoreIssueEncountered(e);
             }
-            return false;
         }
         return super.hasChild(element);
     }
@@ -86,13 +83,12 @@ class CredentialStoreResource extends DelegatingResource {
         if (ElytronDescriptionConstants.ALIAS.equals(element.getKey())) {
             try {
                 CredentialStore credentialStore = credentialStoreServiceController != null ? credentialStoreServiceController.getValue() : null;
-                if (credentialStore != null && (credentialStore.getAliases().contains(toLower(element.getValue())))) {
+                if (credentialStore != null && (credentialStore.getAliases().contains(element.getValue()))) {
                     return Resource.Factory.create(true);
                 }
             } catch (CredentialStoreException e) {
                 ElytronSubsystemMessages.ROOT_LOGGER.credentialStoreIssueEncountered(e);
             }
-            return null;
         }
         return super.getChild(element);
     }
@@ -117,7 +113,6 @@ class CredentialStoreResource extends DelegatingResource {
             } catch (CredentialStoreException e) {
                 ElytronSubsystemMessages.ROOT_LOGGER.credentialStoreIssueEncountered(e);
             }
-            return Collections.emptySet();
         }
         return super.getChildrenNames(childType);
     }
@@ -162,10 +157,6 @@ class CredentialStoreResource extends DelegatingResource {
         }
     }
 
-    private String toLower(String parameter) {
-        return parameter != null ? parameter.toLowerCase(Locale.ROOT) : null;
-    }
-
     @Override
     public Resource removeChild(PathElement element) {
         if (!ElytronDescriptionConstants.ALIAS.equals(element.getKey())) {
@@ -191,5 +182,4 @@ class CredentialStoreResource extends DelegatingResource {
             throw ControllerLogger.ROOT_LOGGER.duplicateResource(element.getValue());
         }
     }
-
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -121,6 +121,13 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
+    static final SimpleAttributeDefinition CASE_SENSITIVE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CASE_SENSITIVE, ModelType.BOOLEAN, true)
+            .setAttributeGroup(ElytronDescriptionConstants.IMPLEMENTATION)
+            .setAllowExpression(false)
+            .setDefaultValue(new ModelNode(false))
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
     // Resource Resolver
     static final StandardResourceDescriptionResolver RESOURCE_RESOLVER = ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.CREDENTIAL_STORE);
 
@@ -128,7 +135,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
     static final SimpleOperationDefinition RELOAD = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.RELOAD, RESOURCE_RESOLVER)
             .build();
 
-    private static final AttributeDefinition[] CONFIG_ATTRIBUTES = new AttributeDefinition[] {URI, CREDENTIAL_REFERENCE, TYPE, PROVIDER_NAME, PROVIDERS, OTHER_PROVIDERS, RELATIVE_TO};
+    private static final AttributeDefinition[] CONFIG_ATTRIBUTES = new AttributeDefinition[] {URI, CREDENTIAL_REFERENCE, TYPE, PROVIDER_NAME, PROVIDERS, OTHER_PROVIDERS, RELATIVE_TO, CASE_SENSITIVE};
 
     private static final CredentialStoreAddHandler ADD = new CredentialStoreAddHandler();
     private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, CREDENTIAL_STORE_RUNTIME_CAPABILITY);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -322,6 +322,8 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 918, value = "Invalid user name '%s' because the realm %s only supports lower case alias names")
     OperationFailedException invalidUsername(String username, String realmName);
 
+    @Message(id = 919, value = "Invalid alias name '%s' because the credential store %s only supports lower case alias names")
+    OperationFailedException invalidAliasName(String alias, String credntialStore);
     /*
      * Identity Resource Messages - 1000
      */

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1177,6 +1177,7 @@ elytron.server-ssl-context.ssl-session.invalidate=Invalidate the SSLSession (Not
 # Credential Store #
 ####################
 elytron.credential-store=Credential store to keep alias for sensitive information such as passwords for external services.
+elytron.credential-store.case-sensitive=Case sensitivity of the credential store. If case insensitive only lower case names are allowed for aliases.
 elytron.credential-store.name=Name of the credential store.
 elytron.credential-store.type=The credential store type, e.g. KeyStoreCredentialStore.
 elytron.credential-store.credential-reference=Credential reference to be used to create protection parameter.

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -4631,6 +4631,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates that the credential sotre is case sensitive and should then allow for upper case in alias.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <!--

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
@@ -14,7 +14,7 @@
         </filesystem-realm>
     </security-realms>
     <credential-stores>
-        <credential-store name="test">
+        <credential-store name="test" case-sensitive="false">
             <uri>cr-store://test/target/tlstest.keystore</uri>
             <credential-reference clear-text="super_secret"/>
         </credential-store>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -50,7 +50,7 @@
         </client-ssl-contexts>
     </tls>
     <credential-stores>
-        <credential-store name="credstore1">
+        <credential-store name="credstore1" case-sensitive="true">
             <uri>cr-store://credstore1</uri>
             <credential-reference store="mystore" alias="the-alias"/>
         </credential-store>


### PR DESCRIPTION
Adding validation step to ensure that  the alias is lower case.
Adding parameter on CredentialStore to allow disabling of this validation in case the store supports case sensitivity.

Jira: https://issues.jboss.org/browse/WFCORE-2556
JBEAP: https://issues.jboss.org/browse/JBEAP-8871
Test update PR : https://github.com/wildfly-security-incubator/wildfly/pull/162