### PR TITLE
[WFCORE-2546] Typo in description of Elytron aggregate-principal-transformer

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -385,7 +385,7 @@ elytron.x500-attribute-principal-decoder.required-attributes=The attributes name
 # Principal Transformers #
 ##########################
 
-elytron.aggregate-principal-transformer=A principa transformer definition where the principal transformer is an aggregation of other principal transformers.
+elytron.aggregate-principal-transformer=A principal transformer definition where the principal transformer is an aggregation of other principal transformers.
 # Operations
 elytron.aggregate-principal-transformer.add=The add operation for the principal transformer.
 elytron.aggregate-principal-transformer.remove=The remove operation for the principal transformer.


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFCORE-2546
JBEAP: https://issues.jboss.org/browse/JBEAP-9627 