### PR TITLE
[WFCORE-2560]: User names in Elytron FileSystemRealm are not case sensitive on Windows.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -71,6 +71,7 @@ interface ElytronDescriptionConstants {
     String BCRYPT_MAPPER = "bcrypt-mapper";
 
     String CACHING_REALM = "caching-realm";
+    String CASE_SENSITIVE = "case-sensitive";
     String CERTIFICATE = "certificate";
     String CERTIFICATE_ATTRIBUTE = "certificate-attribute";
     String CERTIFICATE_CHAIN = "certificate-chain";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
@@ -23,6 +23,7 @@ import static org.wildfly.extension.elytron.Capabilities.SECURITY_REALM_RUNTIME_
 import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
 import static org.wildfly.extension.elytron.FileAttributeDefinitions.pathName;
 import static org.wildfly.extension.elytron.FileAttributeDefinitions.pathResolver;
+import static org.wildfly.extension.elytron.RealmDefinitions.CASE_SENSITIVE;
 
 import java.nio.file.Path;
 import java.security.KeyStore;
@@ -79,7 +80,7 @@ class FileSystemRealmDefinition extends SimpleResourceDefinition {
                     .setAllowExpression(true)
                     .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{PATH, RELATIVE_TO, LEVELS};
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{PATH, RELATIVE_TO, LEVELS, CASE_SENSITIVE};
 
     private static final AbstractAddStepHandler ADD = new RealmAddHandler();
     private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY, SECURITY_REALM_RUNTIME_CAPABILITY);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
@@ -503,7 +503,7 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
         }
     }
 
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {PrincipalQueryAttributes.PRINCIPAL_QUERIES};
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {PrincipalQueryAttributes.PRINCIPAL_QUERIES, RealmDefinitions.CASE_SENSITIVE};
 
     private static final AbstractAddStepHandler ADD = new RealmAddHandler();
     private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, SECURITY_REALM_RUNTIME_CAPABILITY);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
@@ -24,6 +24,7 @@ import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
 import static org.wildfly.extension.elytron.ElytronExtension.getRequiredService;
 import static org.wildfly.extension.elytron.FileAttributeDefinitions.RELATIVE_TO;
 import static org.wildfly.extension.elytron.FileAttributeDefinitions.pathName;
+import static org.wildfly.extension.elytron.RealmDefinitions.CASE_SENSITIVE;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
 import java.io.File;
@@ -116,7 +117,7 @@ class PropertiesRealmDefinition extends TrivialResourceDefinition {
         .setStorageRuntime()
         .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { USERS_PROPERTIES, GROUPS_PROPERTIES, GROUPS_ATTRIBUTE };
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { USERS_PROPERTIES, GROUPS_PROPERTIES, GROUPS_ATTRIBUTE, CASE_SENSITIVE };
 
     // Resource Resolver
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RealmDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RealmDefinitions.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -67,6 +68,11 @@ class RealmDefinitions {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
+    public static final SimpleAttributeDefinition CASE_SENSITIVE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CASE_SENSITIVE, ModelType.BOOLEAN, true)
+            .setAllowExpression(false)
+            .setDefaultValue(new ModelNode(false))
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
 
     static AttributeDefinition[] IDENTITY_REALM_ATTRIBUTES = { IDENTITY, ATTRIBUTE_NAME, ATTRIBUTE_VALUES };
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RealmParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RealmParser.java
@@ -76,10 +76,11 @@ class RealmParser {
             .addAttribute(PrincipalQueryAttributes.PRINCIPAL_QUERIES, AttributeParser.UNWRAPPED_OBJECT_LIST_PARSER, AttributeMarshaller.UNWRAPPED_OBJECT_LIST_MARSHALLER)
             .build();
     private final PersistentResourceXMLDescription keyStoreRealmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.KEY_STORE_REALM), null)
-            .addAttributes(KeyStoreRealmDefinition.KEYSTORE)
+            .addAttribute(KeyStoreRealmDefinition.KEYSTORE)
             .build();
     private final PersistentResourceXMLDescription propertiesRealmParser = builder(PathElement.pathElement(ElytronDescriptionConstants.PROPERTIES_REALM), null)
             .addAttributes(PropertiesRealmDefinition.GROUPS_ATTRIBUTE)
+            .addAttribute(RealmDefinitions.CASE_SENSITIVE)
             .addAttribute(PropertiesRealmDefinition.USERS_PROPERTIES, AttributeParser.OBJECT_PARSER, AttributeMarshaller.ATTRIBUTE_OBJECT)
             .addAttribute(PropertiesRealmDefinition.GROUPS_PROPERTIES, AttributeParser.OBJECT_PARSER, AttributeMarshaller.ATTRIBUTE_OBJECT)
             .build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -27,6 +27,7 @@ import static org.wildfly.extension.elytron.Capabilities.SSL_CONTEXT_CAPABILITY;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.JWT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.OAUTH2_INTROSPECTION;
 import static org.wildfly.extension.elytron.ElytronExtension.asStringIfDefined;
+import static org.wildfly.extension.elytron.RealmDefinitions.CASE_SENSITIVE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.AUDIENCE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.CERTIFICATE;
 import static org.wildfly.extension.elytron.TokenRealmDefinition.JwtValidatorAttributes.ISSUER;
@@ -195,7 +196,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
         }
     }
 
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{PRINCIPAL_CLAIM, JwtValidatorAttributes.JWT_VALIDATOR, OAuth2IntrospectionValidatorAttributes.OAUTH2_INTROSPECTION_VALIDATOR};
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{PRINCIPAL_CLAIM, JwtValidatorAttributes.JWT_VALIDATOR, OAuth2IntrospectionValidatorAttributes.OAUTH2_INTROSPECTION_VALIDATOR, CASE_SENSITIVE};
 
     private static final AbstractAddStepHandler ADD = new RealmAddHandler();
     private static final OperationStepHandler REMOVE = new TrivialCapabilityServiceRemoveHandler(ADD, MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY, SECURITY_REALM_RUNTIME_CAPABILITY);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -315,6 +315,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 917, value = "Password cannot be resolved for dir-context")
     StartException dirContextPasswordCannotBeResolved(@Cause Exception cause);
 
+    @Message(id = 918, value = "Invalid user name '%s' because the realm %s only supports lower case alias names")
+    OperationFailedException invalidUsername(String username, String realmName);
+
     /*
      * Identity Resource Messages - 1000
      */

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -561,10 +561,11 @@ elytron.custom-modifiable-realm=Custom realm configured as being modifiable will
 elytron.custom-modifiable-realm.add=The add operation for the security realm.
 elytron.custom-modifiable-realm.remove=The remove operation for the security realm.
 # Attributes
-elytron.custom-modifiable-realm.module=The module to use to load the custom realm.
+#elytron.custom-modifiable-realm.case-sensitive=Case sensitivity of the custom realm. If case insensitive only lower usernames are allowed.
 elytron.custom-modifiable-realm.class-name=The class name of the implementation of the custom realm.
 elytron.custom-modifiable-realm.configuration=The optional key/value configuration for the custom realm.
 elytron.custom-modifiable-realm.identity=An identity which can be managed by a security realm.
+elytron.custom-modifiable-realm.module=The module to use to load the custom realm.
 
 elytron.custom-realm=A custom realm definitions can implement either the SecurityRealm interface or the ModifiableSecurityRealm interface. Regardless of which interface is implemented management operations will not be exposed to manage the realm.  However other services that depend on the realm will still be able to perform a type check and cast to gain access to the modification API.
 # Operations
@@ -580,6 +581,7 @@ elytron.jdbc-realm=A security realm definition backed by database using JDBC.
 # Operations
 elytron.jdbc-realm.add=The add operation for the security realm.
 elytron.jdbc-realm.remove=The remove operation for the security realm.
+elytron.jdbc-realm.case-sensitive=Case sensitivity of the JDBC realm. If case insensitive only lower usernames are allowed.
 
 # Authentication Query Complex Attribute
 elytron.jdbc-realm.principal-query=The authentication query used to authenticate users based on specific key types.
@@ -620,6 +622,7 @@ elytron.properties-realm=A security realm definition backed by properties files.
 # Operations
 elytron.properties-realm.add=The add operation for the security realm.
 elytron.properties-realm.remove=The remove operation for the security realm.
+elytron.properties-realm.case-sensitive=Case sensitivity of the properties realm. If case insensitive only lower usernames are allowed.
 elytron.properties-realm.load=Reload the properties files from the file system.
 # Attributes
 elytron.properties-realm.users-properties=The properties file containing the users and their passwords.
@@ -639,6 +642,7 @@ elytron.ldap-realm=A security realm definition backed by LDAP.
 elytron.ldap-realm.add=The add operation for the security realm.
 elytron.ldap-realm.remove=The remove operation for the security realm.
 # Attributes
+elytron.ldap-realm.case-sensitive=Case sensitivity of the LDAP realm. If case insensitive only lower usernames are allowed.
 elytron.ldap-realm.dir-context=The configuration to connect to a LDAP server.
 elytron.ldap-realm.dir-context.url=The connection url.
 elytron.ldap-realm.dir-context.authentication-level=The authentication level.
@@ -690,6 +694,7 @@ elytron.ldap-realm.identity=An identity which can be managed by a security realm
 elytron.filesystem-realm=A simple security realm definition backed by the filesystem.
 elytron.filesystem-realm.add=The add operation for the security realm.
 elytron.filesystem-realm.remove=The remove operation for the security realm.
+elytron.filesystem-realm.case-sensitive=Case sensitivity of the filesystem realm. If case insensitive only lower usernames are allowed.
 elytron.filesystem-realm.path=The path to the file containing the realm.
 elytron.filesystem-realm.relative-to=The pre-defined path the path is relative to.
 elytron.filesystem-realm.levels=The number of levels of directory hashing to apply.
@@ -701,6 +706,7 @@ elytron.token-realm.add=The add operation for the security realm.
 elytron.token-realm.remove=The remove operation for the security realm.
 # Attributes
 elytron.token-realm.principal-claim=The name of the claim that should be used to obtain the principal's name.
+elytron.token-realm.case-sensitive=Case sensitivity of the token realm. If case insensitive only lower usernames are allowed.
 # JWT Validator Complex Attribute
 elytron.token-realm.jwt=A token validator to be used in conjunction with a token-based realm that handles security tokens based on the JWT/JWS standard.
 elytron.token-realm.jwt.issuer=A list of strings representing the issuers supported by this configuration. During validation JWT tokens must have an "iss" claim that contains one of the values defined here.

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -964,6 +964,13 @@
                 <xs:sequence>
                     <xs:element name="principal-query" type="authenticationQueryType" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the realm is case sensitive and should then allow for upper case in user names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1252,6 +1259,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the realm is case sensitive and should then allow for upper case in user names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1309,6 +1323,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the realm is case sensitive and should then allow for upper case in user names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1347,6 +1368,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the realm is case sensitive and should then allow for upper case in user names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1376,6 +1404,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the realm is case sensitive and should then allow for upper case in user names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1397,6 +1432,13 @@
                     <xs:annotation>
                         <xs:documentation>
                             The name of the claim that should be used to obtain the principal's name. Defaults to 'username'.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the realm is case sensitive and should then allow for upper case in user names.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -1445,6 +1487,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates that the realm is case sensitive and should then allow for upper case in user names.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="oauth2IntrospectionTokenRealmValidatorType">
@@ -1485,6 +1534,13 @@
             <xs:annotation>
                 <xs:documentation>
                     A policy that defines how host names should be verified when using HTTPS. Allowed values: "ANY".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates that the realm is case sensitive and should then allow for upper case in user names.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -4559,15 +4615,15 @@
     </xs:complexType>
 
     <!--
-        General Types
-     -->
+       General Types
+    -->
 
-     <xs:complexType name="basicFileType">
-         <xs:annotation>
-             <xs:documentation>
-                 Minimal attributes required to specify the location to a file.
-             </xs:documentation>
-         </xs:annotation>
+    <xs:complexType name="basicFileType">
+        <xs:annotation>
+            <xs:documentation>
+                Minimal attributes required to specify the location to a file.
+            </xs:documentation>
+        </xs:annotation>
         <xs:attribute name="relative-to" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
@@ -4583,7 +4639,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-     </xs:complexType>
+    </xs:complexType>
 
     <xs:complexType name="fileType">
         <xs:annotation>
@@ -4594,7 +4650,7 @@
         <xs:complexContent>
             <xs:extension base="basicFileType">
                 <xs:attribute name="required" type="xs:boolean"
-                    use="optional" default="false">
+                              use="optional" default="false">
                     <xs:annotation>
                         <xs:documentation>
                             It is possible that a KeyStore definition can be created to a

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/identity-management.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/identity-management.xml
@@ -8,7 +8,7 @@
         </security-domain>
     </security-domains>
     <security-realms>
-        <filesystem-realm name="FileSystemRealm">
+        <filesystem-realm name="FileSystemRealm" case-sensitive="true">
             <file path="filesystem-realm-empty" relative-to="jboss.server.config.dir"/>
         </filesystem-realm>
     </security-realms>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -9,12 +9,12 @@
             <users-properties path="target/test-classes/org/wildfly/extension/elytron/users-hashed.properties" digest-realm-name="Hashed" />
         </properties-realm>
 
-        <properties-realm name="ClearPropertyRealm" groups-attribute="groupAttr">
+        <properties-realm name="ClearPropertyRealm" groups-attribute="groupAttr" case-sensitive="true">
             <users-properties path="users-clear.properties" relative-to="jboss.server.config.dir" plain-text="true" />
             <groups-properties path="groups.properties" relative-to="jboss.server.config.dir" />
         </properties-realm>
 
-        <filesystem-realm name="FilesystemRealm" levels="2">
+        <filesystem-realm name="FilesystemRealm" levels="2" case-sensitive="true">
             <file path="filesystem-realm" relative-to="jboss.server.config.dir" />
         </filesystem-realm>
 
@@ -22,7 +22,7 @@
             <jwt issuer="some-issuer-a some-issuer-b" audience="some-audience-a some-audience-b some-audience-c" public-key="-----BEGIN PUBLIC KEY-----MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB-----END PUBLIC KEY-----"/>
         </token-realm>
 
-        <token-realm name="EmptyJwtRealm" principal-claim="sub">
+        <token-realm name="EmptyJwtRealm" principal-claim="sub" case-sensitive="true">
             <jwt/>
         </token-realm>
 
@@ -30,7 +30,7 @@
             <jwt key-store="ElytronCaTruststore" certificate="mykey" />
         </token-realm>
 
-        <token-realm name="OAuth2Realm" principal-claim="sub">
+        <token-realm name="OAuth2Realm" principal-claim="sub" case-sensitive="true">
             <oauth2-introspection client-id="a" client-secret="b" introspection-url="https://localhost/token/introspect" client-ssl-context="ClientCaSslContext" host-name-verification-policy="ANY" />
         </token-realm>
     </security-realms>


### PR DESCRIPTION
Add case-sensitive attribute to realms to indicate if those are supporting principals with upper case chars or only principals in lower case.

Jira: https://issues.jboss.org/browse/WFCORE-2560
JBEAP: https://issues.jboss.org/browse/JBEAP-8810
Full Elytron test suite update: https://github.com/wildfly-security-incubator/wildfly/pull/165