### PR TITLE
[WFCORE-2163]: Server does not start when Elytron authentication + legacy SSL is used in HTTP management interface

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -172,9 +172,11 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
             undertowBuilder.addDependency(context.getCapabilityServiceName(
                     buildDynamicCapabilityName(HTTP_AUTHENTICATION_FACTORY_CAPABILITY, httpAuthenticationFactory),
                     HttpAuthenticationFactory.class), HttpAuthenticationFactory.class, undertowService.getHttpAuthenticationFactoryInjector());
-        } else if (securityRealm != null) {
+        }
+        if (securityRealm != null) {
             SecurityRealm.ServiceUtil.addDependency(undertowBuilder, undertowService.getSecurityRealmInjector(), securityRealm, false);
-        } else {
+        }
+        if(httpAuthenticationFactory == null && securityRealm == null) {
             ServerLogger.ROOT_LOGGER.httpManagementInterfaceIsUnsecured();
         }
         String sslContext = commonPolicy.getSSLContext();


### PR DESCRIPTION
SecurityRealm was ignored if 'http-authentication-factory' was set.

Jira: https://issues.jboss.org/browse/WFCORE-2163
JBEAP: https://issues.jboss.org/browse/JBEAP-7428