### PR TITLE
[WFCORE-2565]: Incorrect permission class-name should throw exception at runtime

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/TrivialResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TrivialResourceDefinition.java
@@ -36,9 +36,9 @@ import org.jboss.msc.service.ServiceName;
  */
 class TrivialResourceDefinition extends SimpleResourceDefinition {
 
-    private final String pathKey;
-    private final RuntimeCapability<?> firstCapability;
-    private final AttributeDefinition[] attributes;
+    protected final String pathKey;
+    protected final RuntimeCapability<?> firstCapability;
+    protected final AttributeDefinition[] attributes;
 
     TrivialResourceDefinition(String pathKey, ResourceDescriptionResolver resourceDescriptionResolver, AbstractAddStepHandler add, AttributeDefinition[] attributes, RuntimeCapability<?> ... runtimeCapabilities) {
         super(new Parameters(PathElement.pathElement(pathKey),

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -287,6 +287,14 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 34, value = "A principal query can only have a single key mapper")
     OperationFailedException jdbcRealmOnlySingleKeyMapperAllowed();
 
+    @Message(id = 35, value = "Exception while loading the permission class '%s' for the permission mapping.")
+    @LogMessage(level = WARN)
+    void exceptionWhileLoadingPermissionClass(String permissionClassName, @Cause Throwable cause);
+
+    @Message(id = 36, value = "Exception while loading the permission module '%s' for the permission mapping.")
+    @LogMessage(level = WARN)
+    void exceptionWhileLoadingPermissionModule(String permissionModuleName, @Cause Throwable cause);
+
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")
     IllegalArgumentException credentialStoreEntryTypeNotSupported(String credentialStoreName, String entryType);


### PR DESCRIPTION
Logging a WARNING when the class of a permission can't be loaded.

Jira: https://issues.jboss.org/browse/WFCORE-2565
JBEAP: https://issues.jboss.org/browse/JBEAP-9726