### PR TITLE
[WFCORE-2579] Rename WildFly Elytron subsystem to wildfly-elytron-integration.

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -26,7 +26,7 @@
         <version>3.0.0.Beta12-SNAPSHOT</version>
     </parent>
 
-    <artifactId>wildfly-elytron</artifactId>
+    <artifactId>wildfly-elytron-integration</artifactId>
 
     <name>WildFly: Elytron Subsystem</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -772,7 +772,7 @@
 
             <dependency>
                 <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-elytron</artifactId>
+                <artifactId>wildfly-elytron-integration</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
:warning: Requires a paired WildFly Change.