### PR TITLE
[WFCORE-2517] Coverity, Dereference after null check (Elytron subsystem)

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/PolicyParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PolicyParser.java
@@ -90,10 +90,12 @@ class PolicyParser {
             switch (localName) {
                 // Permission Mapper
                 case JACC_POLICY:
-                    providerFound = defaultPolicy.equals(parseJaccPolicy(addPolicy, reader, operations)) || providerFound;
+                    String jaccPolicy = parseJaccPolicy(addPolicy, reader, operations);
+                    providerFound = providerFound || defaultPolicy.equals(jaccPolicy);
                     break;
                 case CUSTOM_POLICY:
-                    providerFound = defaultPolicy.equals(parseCustomPolicy(addPolicy, reader, operations)) || providerFound;
+                    String customPolicy = parseCustomPolicy(addPolicy, reader, operations);
+                    providerFound = providerFound || defaultPolicy.equals(customPolicy);
                     break;
                 default:
                     throw unexpectedElement(reader);


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-2517
JBEAP: https://issues.jboss.org/browse/JBEAP-9475