### PR TITLE
[WFCORE-2457][JBEAP-6805] Improve failure description message for filters of Elytron

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -199,7 +199,7 @@ class SaslServerDefinitions {
 
             if (value.hasDefined(ElytronDescriptionConstants.PREDEFINED_FILTER)
                     && value.hasDefined(ElytronDescriptionConstants.PATTERN_FILTER)) {
-                throw ROOT_LOGGER.invalidDefinition(ElytronDescriptionConstants.FILTERS);
+                throw ROOT_LOGGER.invalidDefinition(ElytronDescriptionConstants.FILTERS, ElytronDescriptionConstants.PREDEFINED_FILTER, ElytronDescriptionConstants.PATTERN_FILTER);
             }
         }
     }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -379,8 +379,8 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1013, value = "Pattern [%s] requires a capture group")
     OperationFailedException patternRequiresCaptureGroup(final String pattern);
 
-    @Message(id = 1014, value = "Invalid [%s] definition.")
-    OperationFailedException invalidDefinition(final String property);
+    @Message(id = 1014, value = "Invalid [%s] definition. Only one of '%s' or '%s' can be set in one Object in the list of filters.")
+    OperationFailedException invalidDefinition(final String property, String filterNameOne, String filterNameTwo);
 
     @Message(id = 1015, value = "Unable to perform automatic outflow for '%s'")
     IllegalStateException unableToPerformOutflow(String identityName, @Cause Exception cause);


### PR DESCRIPTION
The failure description message has been improved with a better explanation if the user uses 'predefined-filter' and 'pattern-filter' in the same object in the filters list.

Jira links:
https://issues.jboss.org/browse/WFCORE-2457
https://issues.jboss.org/browse/JBEAP-6805