### PR TITLE
[WFCORE-2570](reopen) Explain the meaning of and set default values of maximum-session-cache-size and session-timeout

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -203,14 +203,14 @@ class SSLDefinitions {
 
     static final SimpleAttributeDefinition MAXIMUM_SESSION_CACHE_SIZE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.MAXIMUM_SESSION_CACHE_SIZE, ModelType.INT, true)
             .setAllowExpression(true)
-            .setDefaultValue(new ModelNode(0))
+            .setDefaultValue(new ModelNode(-1))
             .setValidator(new IntRangeValidator(-1))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     static final SimpleAttributeDefinition SESSION_TIMEOUT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SESSION_TIMEOUT, ModelType.INT, true)
             .setAllowExpression(true)
-            .setDefaultValue(new ModelNode(0))
+            .setDefaultValue(new ModelNode(-1))
             .setValidator(new IntRangeValidator(-1))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-2570 (reopen)
JBEAP: https://issues.jboss.org/browse/JBEAP-9780