### PR TITLE
[WFCORE-2662] caching-realm - listening optional

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -223,6 +223,7 @@ interface ElytronDescriptionConstants {
     String LEFT = "left";
     String LESS_THAN = "less-than";
     String LEVELS = "levels";
+    String LISTENING = "listening";
     String LOAD = "load";
     String LOAD_SERVICES = "load-services";
     String LOADED_PROVIDER = "loaded-provider";

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -784,6 +784,7 @@ elytron.caching-realm.remove=The remove operation for the security realm.
 elytron.caching-realm.realm=A reference to a cacheable security realm.
 elytron.caching-realm.maximum-entries=The maximum number of entries to keep in the cache.
 elytron.caching-realm.maximum-age=The time in milliseconds that an item can stay in the cache.
+elytron.caching-realm.listening=Whether the caching realm should listen for changes in cached realm and invalidate cache automatically.
 elytron.caching-realm.clear-cache=Removes all entries from the cache.
 
 

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -897,6 +897,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="listening" type="xs:boolean" use="optional" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the caching realm should listen for changes in cached realm and invalidate cache automatically.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -33,6 +33,9 @@
         <token-realm name="OAuth2Realm" principal-claim="sub" case-sensitive="true">
             <oauth2-introspection client-id="a" client-secret="b" introspection-url="https://localhost/token/introspect" client-ssl-context="ClientCaSslContext" host-name-verification-policy="ANY" />
         </token-realm>
+
+        <caching-realm name="CachingRealm" realm="FilesystemRealm" maximum-age="10" maximum-entries="5" listening="false"/>
+
     </security-realms>
 
     <tls><!-- required by OAuth2Realm when HTTPS in introspection-url used -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2662
https://issues.jboss.org/browse/JBEAP-8679
connected with https://github.com/wildfly-security/wildfly-elytron/pull/769

Listening for changes in cached realm made optional - added attribute "listening" which can be set to false to prevent watching the LDAP and similar.