### PR TITLE
[WFCORE-2493][JBEAP-6815]: Rename attribute http-server-factories in Elytron aggregate-http-server-mechanism-factory

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -184,7 +184,7 @@ interface ElytronDescriptionConstants {
     String HTTP = "http";
     String HTTP_AUTHENTICATION_FACTORY = "http-authentication-factory";
     String HTTP_SERVER_MECHANISM_FACTORY = "http-server-mechanism-factory";
-    String HTTP_SERVER_FACTORIES = "http-server-factories";
+    String HTTP_SERVER_MECHANISM_FACTORIES = "http-server-mechanism-factories";
 
     String IDENTITY = "identity";
     String IDENTITY_MAPPING = "identity-mapping";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpParser.java
@@ -35,7 +35,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILTER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILTERS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HTTP;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HTTP_AUTHENTICATION_FACTORY;
-import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HTTP_SERVER_FACTORIES;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORIES;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORY;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.MODULE;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.NAME;
@@ -396,7 +396,7 @@ class HttpParser {
                 writer.writeStartElement(AGGREGATE_HTTP_SERVER_MECHANISM_FACTORY);
                 writer.writeAttribute(NAME, name);
 
-                List<ModelNode> serverFactoryReferences = serverFactory.get(HTTP_SERVER_FACTORIES).asList();
+                List<ModelNode> serverFactoryReferences = serverFactory.get(HTTP_SERVER_MECHANISM_FACTORIES).asList();
                 for (ModelNode currentReference : serverFactoryReferences) {
                     writer.writeStartElement(HTTP_SERVER_MECHANISM_FACTORY);
                     writer.writeAttribute(NAME, currentReference.asString());

--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -109,7 +109,7 @@ class HttpServerDefinitions {
         .build();
 
     private static final AggregateComponentDefinition<HttpServerAuthenticationMechanismFactory> AGGREGATE_HTTP_SERVER_FACTORY = AggregateComponentDefinition.create(HttpServerAuthenticationMechanismFactory.class,
-            ElytronDescriptionConstants.AGGREGATE_HTTP_SERVER_MECHANISM_FACTORY, ElytronDescriptionConstants.HTTP_SERVER_FACTORIES, HTTP_SERVER_MECHANISM_FACTORY_RUNTIME_CAPABILITY,
+            ElytronDescriptionConstants.AGGREGATE_HTTP_SERVER_MECHANISM_FACTORY, ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORIES, HTTP_SERVER_MECHANISM_FACTORY_RUNTIME_CAPABILITY,
             (HttpServerAuthenticationMechanismFactory[] n) -> new AggregateServerMechanismFactory(n));
 
     static AggregateComponentDefinition<HttpServerAuthenticationMechanismFactory> getRawAggregateHttpServerFactoryDefinition() {

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -220,7 +220,7 @@ elytron.aggregate-http-server-mechanism-factory=A http server factory definition
 elytron.aggregate-http-server-mechanism-factory.add=The add operation for the http server factory.
 elytron.aggregate-http-server-mechanism-factory.remove=The remove operation for the http server factory.
 # Attributes
-elytron.aggregate-http-server-mechanism-factory.http-server-factories=The referenced http server factories to aggregate.
+elytron.aggregate-http-server-mechanism-factory.http-server-mechanism-factories=The referenced http server factories to aggregate.
 # Runtime Attributes
 elytron.aggregate-http-server-mechanism-factory.available-mechanisms=The HTTP mechanisms available from this factory instance.
 


### PR DESCRIPTION
Attribute http-server-factories in aggregate-http-server-mechanism-factory has been renamed to http-server-mechanism-factories:

Before:
`/subsystem=elytron/aggregate-http-server-mechanism-factory=test:add(http-server-factories=`

Now:
`/subsystem=elytron/aggregate-http-server-mechanism-factory=test:add(http-server-mechanism-factories=`

Jira issues:
https://issues.jboss.org/browse/WFCORE-2493
https://issues.jboss.org/browse/JBEAP-6815