### PR TITLE
WFCORE-2500 Elytron: setting reload-required on http-server-mechanism…

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -109,7 +109,7 @@ class AuthenticationFactoryDefinitions {
     static final SimpleAttributeDefinition MECHANISM_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.MECHANISM_NAME, ModelType.STRING, true)
             .setAllowExpression(true)
             .setMinSize(1)
-            .setRestartAllServices()
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setAttributeGroup(ElytronDescriptionConstants.SELECTION_CRITERIA)
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -96,7 +96,7 @@ class AuthenticationFactoryDefinitions {
 
     static final SimpleAttributeDefinition HTTP_SERVER_MECHANISM_FACTORY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORY, ModelType.STRING, false)
             .setMinSize(1)
-            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setRestartAllServices()
             .setCapabilityReference(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, HTTP_AUTHENTICATION_FACTORY_CAPABILITY, true)
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TrivialResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TrivialResourceDefinition.java
@@ -21,10 +21,12 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.msc.service.ServiceName;
@@ -61,9 +63,11 @@ class TrivialResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
          if (attributes != null && attributes.length > 0) {
-             WriteAttributeHandler write = new WriteAttributeHandler(pathKey, attributes);
+             WriteAttributeHandler restartParentWriteHandler = new WriteAttributeHandler(pathKey, attributes);
+             ReloadRequiredWriteAttributeHandler reloadRequiredWriteHandler = new ReloadRequiredWriteAttributeHandler(attributes);
              for (AttributeDefinition current : attributes) {
-                 resourceRegistration.registerReadWriteAttribute(current, null, write);
+                 boolean restartAll = current.getFlags().contains(AttributeAccess.Flag.RESTART_ALL_SERVICES);
+                 resourceRegistration.registerReadWriteAttribute(current, null, restartAll ? reloadRequiredWriteHandler : restartParentWriteHandler);
              }
          }
     }


### PR DESCRIPTION
…-factory of http-authentication-factory

https://issues.jboss.org/browse/WFCORE-2500
https://issues.jboss.org/browse/JBEAP-9373

This reverts the original PR https://github.com/wildfly-security-incubator/wildfly-core/pull/76, where I set the flags on a wrong attribute, and makes the change on a correct attribute.