### PR TITLE
[WFCORE-2478][JBEAP-9211]: Allow the creation of empty credential stores

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreService.java
@@ -114,6 +114,9 @@ class CredentialStoreService implements Service<CredentialStore> {
             credentialStoreAttributes.put(CS_LOCATION_ATTRIBUTE, loc.toAbsolutePath().toString());
             credentialStore = getCredentialStoreInstance();
             credentialStore.initialize(credentialStoreAttributes, resolveCredentialStoreProtectionParameter(), otherProviders.getOptionalValue());
+            if ( credentialStoreAttributes.get(ElytronDescriptionConstants.CREATE).equals("true") && !loc.toFile().exists() ){
+                credentialStore.flush();
+            }
         } catch (Exception e) {
             throw ElytronSubsystemMessages.ROOT_LOGGER.unableToStartService(e);
         }


### PR DESCRIPTION
Currently, the credential stores are being created only when the user adds an alias. This issue allows the creation of empty credential stores. The CLI command must use modifiable=true to create the empty credential store.

Jira issues are:
https://issues.jboss.org/browse/WFCORE-2478
https://issues.jboss.org/browse/JBEAP-9211