### PR TITLE
[WFCORE-2646] Only test if the realm is ready for authentication if it is actually being used for authentication.

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -252,7 +252,7 @@ public class ManagementHttpServer {
     }
 
     private static Function<HttpServerExchange, Boolean> createReadyFunction(Builder builder) {
-        if (builder.securityRealm != null) {
+        if (builder.securityRealm != null && builder.httpAuthenticationFactory == null) {
             final SecurityRealm securityRealm = builder.securityRealm;
             return e -> securityRealm.isReadyForHttpChallenge() || clientCertPotentiallyPossible(securityRealm, e);
         } else {


### PR DESCRIPTION

https://issues.jboss.org/browse/WFCORE-2646
https://issues.jboss.org/browse/JBEAP-10226