### PR TITLE
[WFCORE-2716][JBEAP-10495]: ssl-context and authentication-context must be mutually exclusive for Elytron dir-context

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -115,13 +115,14 @@ class DirContextDefinition extends SimpleResourceDefinition {
             .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setCapabilityReference(AUTHENTICATION_CONTEXT_CAPABILITY, DIR_CONTEXT_CAPABILITY, true)
-            .setAlternatives(CredentialReference.CREDENTIAL_REFERENCE)
+            .setAlternatives(CredentialReference.CREDENTIAL_REFERENCE, ElytronDescriptionConstants.SSL_CONTEXT)
             .build();
 
     static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SSL_CONTEXT, ModelType.STRING, true)
             .setAllowExpression(false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setCapabilityReference(SSL_CONTEXT_CAPABILITY, DIR_CONTEXT_CAPABILITY, true)
+            .setAlternatives(ElytronDescriptionConstants.AUTHENTICATION_CONTEXT)
             .build();
 
     static final SimpleAttributeDefinition CONNECTION_TIMEOUT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CONNECTION_TIMEOUT, ModelType.INT, true)


### PR DESCRIPTION
To avoid possibility when two different ssl-contexts are configured in Elytron dir-context, its attributes ssl-context and authentication-context should be mutually exclusive.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2716
https://issues.jboss.org/browse/JBEAP-10495