### PR TITLE
[WFCORE-2671][JBEAP-10328] key-managers to key-manager, key-manager:init()

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
@@ -527,7 +527,7 @@ public class LsHandler extends BaseOperationCommand {
         return address;
     }
 
-    protected String getNodePath(String nodePathString) {
+    protected static String getNodePath(String nodePathString) {
         int i = 0;
         while(i < nodePathString.length()) {
             i = nodePathString.indexOf('-', i);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/PrefixHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/PrefixHandler.java
@@ -65,7 +65,10 @@ public class PrefixHandler extends CommandHandlerWithHelp {
         }
 
         final OperationRequestAddress tmp = new DefaultOperationRequestAddress(prefix);
-        ctx.getCommandLineParser().parse(ctx.getArgumentsString(), new DefaultCallbackHandler(tmp));
+
+        // We need to remove any option
+        String np = LsHandler.getNodePath(ctx.getArgumentsString());
+        ctx.getCommandLineParser().parse(np, new DefaultCallbackHandler(tmp));
         if(!noValidation.isPresent(ctx.getParsedCommandLine())) {
             assertValid(ctx, tmp);
         }

--- a/cli/src/main/resources/help/module.txt
+++ b/cli/src/main/resources/help/module.txt
@@ -56,13 +56,13 @@ ARGUMENTS
  --resources     - (used with add, resources and/or absolute-resources is required
                    unless module-xml is used) a list of filesystem paths
                    (usually jar files) separated by a filesystem-specific
-                   path separator, i.e. java.io.File.pathSeparatorChar.
+                   path separator, i.e. '/' for Linux and '\' for Windows.
                    The file(s) specified will be copied to the created module's directory.
 
  --absolute-resources - (used with add, resources and/or absolute-resources required
                        unless module-xml is used) a list of filesystem paths
                        (usually jar files) separated by a filesystem-specific
-                       path separator, i.e. java.io.File.pathSeparatorChar.
+                       path separator, i.e. '/' for Linux and '\' for Windows.
                        The file(s) specified will *NOT* be copied to the created
                        module's directory and will be referenced with absolute path(s).
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2581,6 +2581,11 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
 
         @Override
+        public boolean hasCapability(String capabilityName) {
+            return managementModel.getCapabilityRegistry().hasCapability(capabilityName, CapabilityScope.GLOBAL);
+        }
+
+        @Override
         public <T> T getCapabilityRuntimeAPI(String capabilityName, Class<T> apiType) throws NoSuchCapabilityException {
             try {
                 return managementModel.getCapabilityRegistry().getCapabilityRuntimeAPI(capabilityName, CapabilityScope.GLOBAL, apiType);

--- a/controller/src/main/java/org/jboss/as/controller/capability/CapabilityServiceSupport.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/CapabilityServiceSupport.java
@@ -49,6 +49,13 @@ public interface CapabilityServiceSupport {
             super(message);
         }
     }
+    /**
+     * Gets whether a runtime capability with the given name is registered.
+     *
+     * @param capabilityName the name of the capability. Cannot be {@code null}
+     * @return {@code true} if there is a capability with the given name registered
+     */
+    boolean hasCapability(String capabilityName);
 
     /**
      * Gets the runtime API associated with a given capability, if there is one.

--- a/core-feature-pack/src/main/resources/content/bin/elytron-tool.bat
+++ b/core-feature-pack/src/main/resources/content/bin/elytron-tool.bat
@@ -1,0 +1,59 @@
+@echo off
+rem -------------------------------------------------------------------------
+rem WildFly Elytron Tool Script for Windows
+rem -------------------------------------------------------------------------
+rem
+rem A tool for management securing sensitive strings
+
+@if not "%ECHO%" == ""  echo %ECHO%
+@if "%OS%" == "Windows_NT" setlocal
+
+if "%OS%" == "Windows_NT" (
+  set "DIRNAME=%~dp0%"
+) else (
+  set DIRNAME=.\
+)
+
+pushd "%DIRNAME%.."
+set "RESOLVED_JBOSS_HOME=%CD%"
+popd
+
+if "x%JBOSS_HOME%" == "x" (
+  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+)
+
+pushd "%JBOSS_HOME%"
+set "SANITIZED_JBOSS_HOME=%CD%"
+popd
+
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: "%JBOSS_HOME%"
+   echo.
+)
+
+rem Setup JBoss specific properties
+if "x%JAVA_HOME%" == "x" (
+  set  JAVA=java
+  echo JAVA_HOME is not set. Unexpected results may occur.
+  echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
+) else (
+  set "JAVA=%JAVA_HOME%\bin\java"
+)
+
+rem Find wildfly-elytron-tool.jar, or we can't continue
+set "JBOSS_RUNJAR=%JBOSS_HOME%\bin\wildfly-elytron-tool.jar"
+if not exist "%JBOSS_RUNJAR%" (
+  echo Could not locate "%JBOSS_RUNJAR%".
+  echo Please check that you are in the bin directory when running this script.
+  goto END
+)
+
+
+"%JAVA%" %JAVA_OPTS% ^
+    -jar "%JBOSS_RUNJAR%" ^
+     %*
+
+:END

--- a/core-feature-pack/src/main/resources/content/bin/elytron-tool.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/elytron-tool.ps1
@@ -1,0 +1,16 @@
+##################################################################
+#                                                               ##
+#   WildFly Elytron Tool Script for Windows                     ##
+#                                                               ##
+##################################################################
+$scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
+. $scripts'\common.ps1'
+
+$JAVA_OPTS = @()
+
+# Sample JPDA settings for remote socket debugging
+#$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
+
+& $JAVA -jar $JBOSS_HOME'\bin\wildfly-elytron-tool.jar' $JAVA_OPTS
+
+Env-Clean-Up

--- a/core-feature-pack/src/main/resources/content/bin/elytron-tool.sh
+++ b/core-feature-pack/src/main/resources/content/bin/elytron-tool.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+DIRNAME=`dirname "$0"`
+PROGNAME=`basename "$0"`
+GREP="grep"
+
+# Use the maximum available, or set MAX_FD != -1 to use that
+MAX_FD="maximum"
+
+#
+# Helper to complain.
+#
+warn() {
+    echo "${PROGNAME}: $*"
+}
+
+#
+# Helper to puke.
+#
+die() {
+    warn $*
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false;
+darwin=false;
+case "`uname`" in
+    CYGWIN*)
+        cygwin=true
+        ;;
+
+    Darwin*)
+        darwin=true
+        ;;
+esac
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+    [ -n "$JBOSS_HOME" ] &&
+        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$JAVA_HOME" ] &&
+        JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+    [ -n "$JAVAC_JAR" ] &&
+        JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
+fi
+
+# Setup JBOSS_HOME
+RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$JBOSS_HOME" = "x" ]; then
+    # get the full path (without any relative bits)
+    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+else
+ SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME/.."; pwd`
+ if [ "$RESOLVED_JBOSS" != "$SANITIZED_JBOSS_HOME" ]; then
+   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+   echo ""
+ fi
+fi
+export JBOSS_HOME
+
+# Setup the JVM
+if [ "x$JAVA" = "x" ]; then
+    if [ "x$JAVA_HOME" != "x" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA="java"
+    fi
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+fi
+
+eval \"$JAVA\" $JAVA_OPTS \
+         -jar \""$JBOSS_HOME"/bin/wildfly-elytron-tool.jar\" \
+         '"$@"'

--- a/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/Capabilities.java
@@ -109,10 +109,10 @@ class Capabilities {
         .Builder.of(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, true, HttpServerAuthenticationMechanismFactory.class)
         .build();
 
-    static final String KEY_MANAGERS_CAPABILITY = CAPABILITY_BASE + "key-managers";
+    static final String KEY_MANAGER_CAPABILITY = CAPABILITY_BASE + "key-manager";
 
-    static final RuntimeCapability<Void> KEY_MANAGERS_RUNTIME_CAPABILITY =  RuntimeCapability
-            .Builder.of(KEY_MANAGERS_CAPABILITY, true, KeyManager[].class)
+    static final RuntimeCapability<Void> KEY_MANAGER_RUNTIME_CAPABILITY =  RuntimeCapability
+            .Builder.of(KEY_MANAGER_CAPABILITY, true, KeyManager.class)
             .build();
 
     static final String KEY_STORE_CAPABILITY = CAPABILITY_BASE + "key-store";
@@ -213,10 +213,10 @@ class Capabilities {
         .Builder.of(SSL_CONTEXT_CAPABILITY, true, SSLContext.class)
         .build();
 
-    static final String TRUST_MANAGERS_CAPABILITY = CAPABILITY_BASE + "trust-managers";
+    static final String TRUST_MANAGER_CAPABILITY = CAPABILITY_BASE + "trust-manager";
 
-    static final RuntimeCapability<Void> TRUST_MANAGERS_RUNTIME_CAPABILITY =  RuntimeCapability
-            .Builder.of(TRUST_MANAGERS_CAPABILITY, true, TrustManager[].class)
+    static final RuntimeCapability<Void> TRUST_MANAGER_RUNTIME_CAPABILITY =  RuntimeCapability
+            .Builder.of(TRUST_MANAGER_CAPABILITY, true, TrustManager.class)
             .build();
 
     static final String DIR_CONTEXT_CAPABILITY = CAPABILITY_BASE + "dir-context";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -192,6 +192,7 @@ interface ElytronDescriptionConstants {
     String IMPLEMENTATION_PROPERTIES = "implementation-properties";
     String INDEX = "index";
     String INFO = "info";
+    String INIT = "init";
     String INITIAL = "initial";
     String INITIAL_PROVIDERS = "initial-providers";
     String INTROSPECTION_URL = "introspection-url";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
@@ -61,7 +61,6 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.dmr.Property;
 import org.jboss.msc.inject.InjectionException;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
@@ -603,8 +602,8 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
 
         @Override
         protected void validateUpdatedModel(OperationContext context, Resource model) throws OperationFailedException {
-            Property property = model.getModel().asProperty();
-            resolveKeyMappers(context, property.getValue().get(0));
+            ModelNode principalQuery = model.getModel().get(ElytronDescriptionConstants.PRINCIPAL_QUERY).get(0);
+            resolveKeyMappers(context, principalQuery);
         }
     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -108,12 +108,12 @@ class PermissionMapperDefinitions {
 
     static final SimpleAttributeDefinition TARGET_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.TARGET_NAME, ModelType.STRING, true)
             .setAllowExpression(true)
-            .setMinSize(1)
+            .setMinSize(0)
             .build();
 
     static final SimpleAttributeDefinition ACTION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ACTION, ModelType.STRING, true)
             .setAllowExpression(true)
-            .setMinSize(1)
+            .setMinSize(0)
             .build();
 
     static final ObjectTypeAttributeDefinition PERMISSION = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.PERMISSION, CLASS_NAME, MODULE, TARGET_NAME, ACTION)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -763,7 +763,7 @@ class SSLDefinitions {
                 .build();
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { CIPHER_SUITE_FILTER, PROTOCOLS,
-                USE_CIPHER_SUITES_ORDER, MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, KEY_MANAGERS, TRUST_MANAGERS, providersDefinition, PROVIDER_NAME };
+                KEY_MANAGERS, TRUST_MANAGERS, providersDefinition, PROVIDER_NAME };
 
         return new SSLContextDefinition(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT, false, new TrivialAddHandler<SSLContext>(SSLContext.class, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
             @Override
@@ -776,9 +776,6 @@ class SSLDefinitions {
                 final String providerName = asStringIfDefined(context, PROVIDER_NAME, model);
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
                 final String cipherSuiteFilter = asStringIfDefined(context, CIPHER_SUITE_FILTER, model);
-                final boolean useCipherSuitesOrder = USE_CIPHER_SUITES_ORDER.resolveModelAttribute(context, model).asBoolean();
-                final int maximumSessionCacheSize = MAXIMUM_SESSION_CACHE_SIZE.resolveModelAttribute(context, model).asInt();
-                final int sessionTimeout = SESSION_TIMEOUT.resolveModelAttribute(context, model).asInt();
 
                 return () -> {
                     X509ExtendedKeyManager keyManager = getX509KeyManager(keyManagersInjector.getOptionalValue());
@@ -793,17 +790,14 @@ class SSLDefinitions {
                     if ( ! protocols.isEmpty()) builder.setProtocolSelector(ProtocolSelector.empty().add(
                             EnumSet.copyOf(protocols.stream().map(Protocol::forName).collect(Collectors.toList()))
                     ));
-                    builder.setClientMode(true)
-                           .setUseCipherSuitesOrder(useCipherSuitesOrder)
-                           .setSessionCacheSize(maximumSessionCacheSize)
-                           .setSessionTimeout(sessionTimeout);
+                    builder.setClientMode(true);
 
                     if (ROOT_LOGGER.isTraceEnabled()) {
                         ROOT_LOGGER.tracef(
                                 "ClientSSLContext supplying:  keyManager = %s  trustManager = %s  providers = %s  " +
-                                "cipherSuiteFilter = %s  protocols = %s  maximumSessionCacheSize = %s  sessionTimeout = %s",
+                                "cipherSuiteFilter = %s  protocols = %s",
                                 keyManager, trustManager, Arrays.toString(providers), cipherSuiteFilter,
-                                Arrays.toString(protocols.toArray()), maximumSessionCacheSize, sessionTimeout
+                                Arrays.toString(protocols.toArray())
                         );
                     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -160,6 +160,7 @@ class SSLDefinitions {
             .setAllowExpression(true)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setValidator(new CipherSuiteFilterValidator())
             .build();
 
     static final String[] ALLOWED_PROTOCOLS = { "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" };
@@ -287,6 +288,24 @@ class SSLDefinitions {
         }
     }
 
+    static class CipherSuiteFilterValidator extends ModelTypeValidator{
+
+        public CipherSuiteFilterValidator() {
+            super(ModelType.STRING, true, true, false);
+        }
+
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName,value);
+            if (value.isDefined()) {
+                try {
+                    CipherSuiteSelector.fromString(value.asString());
+                }catch (IllegalArgumentException e){
+                    throw ROOT_LOGGER.invalidCipherSuiteFilter(e, e.getLocalizedMessage());
+                }
+            }
+        }
+    }
 
     static ResourceDefinition getKeyManagerDefinition() {
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -194,7 +194,7 @@ class TlsParser {
             throw missingRequired(reader, requiredAttributes);
         }
 
-        addKeyManager.get(OP_ADDR).set(parentAddress).add(KEY_MANAGERS, name);
+        addKeyManager.get(OP_ADDR).set(parentAddress).add(KEY_MANAGER, name);
         list.add(addKeyManager);
 
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
@@ -264,7 +264,7 @@ class TlsParser {
             throw missingRequired(reader, requiredAttributes);
         }
 
-        addKeyManager.get(OP_ADDR).set(parentAddress).add(TRUST_MANAGERS, name);
+        addKeyManager.get(OP_ADDR).set(parentAddress).add(TRUST_MANAGER, name);
 
         readCertificateRevocationList(reader, addKeyManager, requiredAttributes);
 
@@ -371,11 +371,11 @@ class TlsParser {
                     case WRAP:
                         SSLDefinitions.WRAP.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
-                    case KEY_MANAGERS:
-                        SSLDefinitions.KEY_MANAGERS.parseAndSetParameter(value, addServerSSLContext, reader);
+                    case KEY_MANAGER:
+                        SSLDefinitions.KEY_MANAGER.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
-                    case TRUST_MANAGERS:
-                        SSLDefinitions.TRUST_MANAGERS.parseAndSetParameter(value, addServerSSLContext, reader);
+                    case TRUST_MANAGER:
+                        SSLDefinitions.TRUST_MANAGER.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
                     case PROVIDERS:
                         SSLDefinitions.PROVIDERS.parseAndSetParameter(value, addServerSSLContext, reader);
@@ -447,11 +447,11 @@ class TlsParser {
                     case SESSION_TIMEOUT:
                         SSLDefinitions.SESSION_TIMEOUT.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
-                    case KEY_MANAGERS:
-                        SSLDefinitions.KEY_MANAGERS.parseAndSetParameter(value, addServerSSLContext, reader);
+                    case KEY_MANAGER:
+                        SSLDefinitions.KEY_MANAGER.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
-                    case TRUST_MANAGERS:
-                        SSLDefinitions.TRUST_MANAGERS.parseAndSetParameter(value, addServerSSLContext, reader);
+                    case TRUST_MANAGER:
+                        SSLDefinitions.TRUST_MANAGER.parseAndSetParameter(value, addServerSSLContext, reader);
                         break;
                     case PROVIDERS:
                         SSLDefinitions.PROVIDERS.parseAndSetParameter(value, addServerSSLContext, reader);
@@ -821,10 +821,10 @@ class TlsParser {
     }
 
     private boolean writeKeyManagers(boolean started, ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
-        if (subsystem.hasDefined(KEY_MANAGERS)) {
+        if (subsystem.hasDefined(KEY_MANAGER)) {
             startTLS(started, writer);
             writer.writeStartElement(KEY_MANAGERS);
-            ModelNode keyManagers = subsystem.require(KEY_MANAGERS);
+            ModelNode keyManagers = subsystem.require(KEY_MANAGER);
             for (String name : keyManagers.keys()) {
                 ModelNode keyManager = keyManagers.require(name);
                 writer.writeStartElement(KEY_MANAGER);
@@ -846,10 +846,10 @@ class TlsParser {
     }
 
     private boolean writeTrustManagers(boolean started, ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
-        if (subsystem.hasDefined(TRUST_MANAGERS)) {
+        if (subsystem.hasDefined(TRUST_MANAGER)) {
             startTLS(started, writer);
             writer.writeStartElement(TRUST_MANAGERS);
-            ModelNode trustManagers = subsystem.require(TRUST_MANAGERS);
+            ModelNode trustManagers = subsystem.require(TRUST_MANAGER);
             for (String name : trustManagers.keys()) {
                 ModelNode trustManager = trustManagers.require(name);
                 writer.writeStartElement(TRUST_MANAGER);
@@ -890,8 +890,8 @@ class TlsParser {
                 SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.SESSION_TIMEOUT.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.WRAP.marshallAsAttribute(serverSSLContext, writer);
-                SSLDefinitions.KEY_MANAGERS.marshallAsAttribute(serverSSLContext, writer);
-                SSLDefinitions.TRUST_MANAGERS.marshallAsAttribute(serverSSLContext, writer);
+                SSLDefinitions.KEY_MANAGER.marshallAsAttribute(serverSSLContext, writer);
+                SSLDefinitions.TRUST_MANAGER.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.PROVIDERS.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.PROVIDER_NAME.marshallAsAttribute(serverSSLContext, writer);
 
@@ -920,8 +920,8 @@ class TlsParser {
                 SSLDefinitions.USE_CIPHER_SUITES_ORDER.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.MAXIMUM_SESSION_CACHE_SIZE.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.SESSION_TIMEOUT.marshallAsAttribute(serverSSLContext, writer);
-                SSLDefinitions.KEY_MANAGERS.marshallAsAttribute(serverSSLContext, writer);
-                SSLDefinitions.TRUST_MANAGERS.marshallAsAttribute(serverSSLContext, writer);
+                SSLDefinitions.KEY_MANAGER.marshallAsAttribute(serverSSLContext, writer);
+                SSLDefinitions.TRUST_MANAGER.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.PROVIDERS.marshallAsAttribute(serverSSLContext, writer);
                 SSLDefinitions.PROVIDER_NAME.marshallAsAttribute(serverSSLContext, writer);
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.extension.elytron._private;
 
+import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
@@ -310,8 +311,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 911, value = "Credential store \"%s\" protection parameter cannot be resolved")
     IOException credentialStoreProtectionParameterCannotBeResolved(String name);
 
+    @LogMessage(level = ERROR)
     @Message(id = 912, value = "Credential store issue encountered")
-    OperationFailedException credentialStoreIssueEncountered(@Cause Exception cause);
+    void credentialStoreIssueEncountered(@Cause Exception cause);
 
     @Message(id = 913, value = "Credential alias \"%s\" of credential type \"%s\" already exists in the store")
     OperationFailedException credentialAlreadyExists(String alias, String credentialType);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -388,4 +388,6 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1016, value = "Server '%s' not known")
     OperationFailedException serverNotKnown(final String serverAddedd, @Cause UnknownHostException e);
 
+    @Message(id = 1017, value = "Invalid value for cipher-suite-filter. %s")
+    OperationFailedException invalidCipherSuiteFilter(@Cause Throwable cause, String causeMessage);
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -300,6 +300,15 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 36, value = "Security realm '%s' has been referenced twice in the same security domain.")
     OperationFailedException realmRefererencedTwice(String realmName);
 
+    /**
+     * A {@link StartException} where a specific type is not type of injected value.
+     *
+     * @param type the type required.
+     * @return The {@link StartException} for the error.
+     */
+    @Message(id = 37, value = "Injected value is not of '%s' type.")
+    StartException invalidTypeInjected(final String type);
+
 
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1025,37 +1025,38 @@ elytron.filtering-key-store.key-store=Name of filtered KeyStore.
 elytron.filtering-key-store.state=The state of the underlying service that represents this KeyStore at runtime, if it is anything other than UP runtime operations will not be available.
 elytron.filtering-key-store.alias=An individual alias within the filtering KeyStore.
 
-elytron.key-managers=A key manager definition for creating the KeyManager[] as used to create an SSLContext.
+elytron.key-manager=A key manager definition for creating the KeyManager as used to create an SSLContext.
 #operations
-elytron.key-managers.add=Add the new key manager definition.
-elytron.key-managers.remove=Remove the key manager definition.
+elytron.key-manager.add=Add the new key manager definition.
+elytron.key-manager.remove=Remove the key manager definition.
+elytron.key-manager.init=Reinitialize key manager.
 # Attributes
-elytron.key-managers.algorithm=The name of the algorithm to use to create the underlying KeyManagerFactory.
-elytron.key-managers.providers=Reference to obtain the Provider[] to use when creating the underlying KeyManagerFactory.
-elytron.key-managers.provider-name=The name of the provider to use to create the underlying KeyManagerFactory.
-elytron.key-managers.credential-reference=The credential reference to decrypt KeyStore item. (Not a password of the KeyStore.)
-elytron.key-managers.credential-reference.store=The name of the credential store holding the alias to credential.
-elytron.key-managers.credential-reference.alias=The alias which denotes stored secret or credential in the store.
-elytron.key-managers.credential-reference.type=The type of credential this reference is denoting.
-elytron.key-managers.credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
-elytron.key-managers.key-store=Reference to the KeyStore to use to initialise the underlying KeyManagerFactory.
-elytron.key-managers.alias-filter=A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+elytron.key-manager.algorithm=The name of the algorithm to use to create the underlying KeyManagerFactory.
+elytron.key-manager.providers=Reference to obtain the Provider[] to use when creating the underlying KeyManagerFactory.
+elytron.key-manager.provider-name=The name of the provider to use to create the underlying KeyManagerFactory.
+elytron.key-manager.credential-reference=The credential reference to decrypt KeyStore item. (Not a password of the KeyStore.)
+elytron.key-manager.credential-reference.store=The name of the credential store holding the alias to credential.
+elytron.key-manager.credential-reference.alias=The alias which denotes stored secret or credential in the store.
+elytron.key-manager.credential-reference.type=The type of credential this reference is denoting.
+elytron.key-manager.credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
+elytron.key-manager.key-store=Reference to the KeyStore to use to initialise the underlying KeyManagerFactory.
+elytron.key-manager.alias-filter=A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
 
-elytron.trust-managers=A trust manager definition for creating the TrustManager[] as used to create an SSLContext.
+elytron.trust-manager=A trust manager definition for creating the TrustManager[] as used to create an SSLContext.
 #operations
-elytron.trust-managers.add=Add the new trust manager definition.
-elytron.trust-managers.remove=Remove the trust manager definition.
+elytron.trust-manager.add=Add the new trust manager definition.
+elytron.trust-manager.remove=Remove the trust manager definition.
 # Attributes
-elytron.trust-managers.algorithm=The name of the algorithm to use to create the underlying TrustManagerFactory.
-elytron.trust-managers.providers=Reference to obtain the Provider[] to use when creating the underlying TrustManagerFactory.
-elytron.trust-managers.provider-name=The name of the provider to use to create the underlying TrustManagerFactory.
-elytron.trust-managers.key-store=Reference to the KeyStore to use to initialise the underlying TrustManagerFactory.
-elytron.trust-managers.alias-filter=A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
-elytron.trust-managers.certificate-revocation-list=Enables certificate revocation list checks to a trust manager.
-elytron.trust-managers.certificate-revocation-list.path=The path to the configuration to use to initialise the provider.
-elytron.trust-managers.certificate-revocation-list.relative-to=The base path of the certificate revocation list file.
-elytron.trust-managers.certificate-revocation-list.maximum-cert-path=The maximum number of non-self-issued intermediate certificates that may exist in a certification path.
-elytron.trust-managers.reload-certificate-revocation-list=Notify the trust manager in order to reload the certificate revocation list, if defined.
+elytron.trust-manager.algorithm=The name of the algorithm to use to create the underlying TrustManagerFactory.
+elytron.trust-manager.providers=Reference to obtain the Provider[] to use when creating the underlying TrustManagerFactory.
+elytron.trust-manager.provider-name=The name of the provider to use to create the underlying TrustManagerFactory.
+elytron.trust-manager.key-store=Reference to the KeyStore to use to initialise the underlying TrustManagerFactory.
+elytron.trust-manager.alias-filter=A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+elytron.trust-manager.certificate-revocation-list=Enables certificate revocation list checks to a trust manager.
+elytron.trust-manager.certificate-revocation-list.path=The path to the configuration to use to initialise the provider.
+elytron.trust-manager.certificate-revocation-list.relative-to=The base path of the certificate revocation list file.
+elytron.trust-manager.certificate-revocation-list.maximum-cert-path=The maximum number of non-self-issued intermediate certificates that may exist in a certification path.
+elytron.trust-manager.reload-certificate-revocation-list=Notify the trust manager in order to reload the certificate revocation list, if defined.
 
 elytron.client-ssl-context=An SSLContext for use on the client side of a connection.
 # operations
@@ -1067,8 +1068,9 @@ elytron.client-ssl-context.protocols=The enabled protocols.
 elytron.client-ssl-context.use-cipher-suites-order=To honor local cipher suites preference.
 elytron.client-ssl-context.maximum-session-cache-size=The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
 elytron.client-ssl-context.session-timeout=The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
-elytron.client-ssl-context.key-managers=Reference to the key managers to use within the SSLContext.
-elytron.client-ssl-context.trust-managers=Reference to the trust managers to use within the SSLContext.
+elytron.client-ssl-context.key-manager=Reference to the key manager to use within the SSLContext.
+elytron.client-ssl-context.key-refresh=Refresh KeyManager used by SSLContext.
+elytron.client-ssl-context.trust-manager=Reference to the trust manager to use within the SSLContext.
 elytron.client-ssl-context.provider-name=The name of the provider to use. If not specified, all providers from providers will be passed to the SSLContext.
 elytron.client-ssl-context.providers=The name of the providers to obtain the Provider[] to use to load the SSLContext.
 # Runtime Attributes
@@ -1133,14 +1135,15 @@ elytron.server-ssl-context.security-domain=The security domain to use for authen
 elytron.server-ssl-context.cipher-suite-filter=The filter to apply to specify the enabled cipher suites.
 elytron.server-ssl-context.protocols=The enabled protocols.
 elytron.server-ssl-context.want-client-auth=To request (but not to require) a client certificate on SSL handshake. If a security domain is referenced and supports X509 evidence, this will be set to true automatically. Ignored when need-client-auth is set.
-elytron.server-ssl-context.need-client-auth=To require a client certificate on SSL handshake. Connection without trusted client certificate (see trust-managers) will be rejected.
+elytron.server-ssl-context.need-client-auth=To require a client certificate on SSL handshake. Connection without trusted client certificate (see trust-manager) will be rejected.
 elytron.server-ssl-context.authentication-optional=Rejecting of the client certificate by the security domain will not prevent the connection. Allows a fall through to use other authentication mechanisms (like form login) when the client certificate is rejected by security domain. Has an effect only when the security domain is set.
 elytron.server-ssl-context.use-cipher-suites-order=To honor local cipher suites preference.
 elytron.server-ssl-context.maximum-session-cache-size=The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
 elytron.server-ssl-context.session-timeout=The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
 elytron.server-ssl-context.wrap=Should the SSLEngine, SSLSocket, and SSLServerSocket instances returned be wrapped to protect against further modification.
-elytron.server-ssl-context.key-managers=Reference to the key managers to use within the SSLContext.
-elytron.server-ssl-context.trust-managers=Reference to the trust managers to use within the SSLContext.
+elytron.server-ssl-context.key-manager=Reference to the key manager to use within the SSLContext.
+elytron.server-ssl-context.key-refresh=Refresh KeyManager used by SSLContext.
+elytron.server-ssl-context.trust-manager=Reference to the trust manager to use within the SSLContext.
 elytron.server-ssl-context.provider-name=The name of the provider to use. If not specified, all providers from providers will be passed to the SSLContext.
 elytron.server-ssl-context.providers=The name of the providers to obtain the Provider[] to use to load the SSLContext.
 # Runtime Attributes

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -4317,27 +4317,6 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="use-cipher-suites-order" type="xs:boolean" default="true">
-            <xs:annotation>
-                <xs:documentation>
-                    Configure the SSLContext to honor local cipher suites preference.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maximum-session-cache-size" type="xs:int" default="-1">
-            <xs:annotation>
-                <xs:documentation>
-                    The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="session-timeout" type="xs:int" default="-1">
-            <xs:annotation>
-                <xs:documentation>
-                    The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="key-managers" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -4202,7 +4202,7 @@
             <xs:annotation>
                 <xs:documentation>
                     To require a client certificate on SSL handshake.
-                    Connection without trusted client certificate (see trust-managers) will be rejected.
+                    Connection without trusted client certificate (see trust-manager) will be rejected.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -4248,17 +4248,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="key-managers" type="xs:string" use="optional">
+        <xs:attribute name="key-manager" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    Reference to the KeyManagers to be used by this SSLContext.
+                    Reference to the KeyManager to be used by this SSLContext.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="trust-managers" type="xs:string" use="optional">
+        <xs:attribute name="trust-manager" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    Reference to the TrustManagers to be used by this SSLContext.
+                    Reference to the TrustManager to be used by this SSLContext.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -4317,14 +4317,14 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="key-managers" type="xs:string" use="optional">
+        <xs:attribute name="key-manager" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    Reference to the KeyManagers to be used by this SSLContext.
+                    Reference to the KeyManager to be used by this SSLContext.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="trust-managers" type="xs:string" use="optional">
+        <xs:attribute name="trust-manager" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     Reference to the TrustManagers to be used by this SSLContext.

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -107,23 +107,23 @@ public class TlsTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testProviderTrustManager() throws Throwable {
-        ServiceName serviceName = Capabilities.TRUST_MANAGERS_RUNTIME_CAPABILITY.getCapabilityServiceName("ProviderTrustManager");
-        TrustManager[] trustManagers = (TrustManager[]) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManagers);
+        ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("ProviderTrustManager");
+        TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(trustManager);
     }
 
     @Test
     public void testRevocationLists() throws Throwable {
-        ServiceName serviceName = Capabilities.TRUST_MANAGERS_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl");
-        TrustManager[] trustManagers = (TrustManager[]) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManagers);
+        ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl");
+        TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(trustManager);
     }
 
     @Test
     public void testRevocationListsDp() throws Throwable {
-        ServiceName serviceName = Capabilities.TRUST_MANAGERS_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl-dp");
-        TrustManager[] trustManagers = (TrustManager[]) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManagers);
+        ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl-dp");
+        TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
+        Assert.assertNotNull(trustManager);
     }
 
     private SSLContext getSslContext(String contextName) {

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
@@ -23,7 +23,7 @@
             <trust-manager name="trustmanager" algorithm="SunX509" key-store="truststore"/>
         </trust-managers>
         <client-ssl-contexts>
-            <client-ssl-context name="audit-ssl" trust-managers="trustmanager" />
+            <client-ssl-context name="audit-ssl" trust-manager="trustmanager" />
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
@@ -63,7 +63,7 @@
          <trust-manager algorithm="SunX509" key-store="ElytronCaTruststore" name="ElytronTrustManager"/>
       </trust-managers>
       <client-ssl-contexts>
-         <client-ssl-context name="LdapSslContext" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2 TLSv1.1" trust-managers="ElytronTrustManager"/>
+         <client-ssl-context name="LdapSslContext" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2 TLSv1.1" trust-manager="ElytronTrustManager"/>
       </client-ssl-contexts>
    </tls>
    <dir-contexts>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -46,7 +46,7 @@
             <trust-manager name="CaTrustManager" algorithm="SunX509" key-store="ElytronCaTruststore"/>
         </trust-managers>
         <client-ssl-contexts>
-            <client-ssl-context name="ClientCaSslContext" trust-managers="CaTrustManager" />
+            <client-ssl-context name="ClientCaSslContext" trust-manager="CaTrustManager" />
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
@@ -64,14 +64,14 @@
             </trust-manager>
         </trust-managers>
         <server-ssl-contexts>
-            <server-ssl-context name="ServerSslContextNoAuth" key-managers="ServerKeyManager" trust-managers="CaTrustManager"/>
-            <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1.3 TLSv1.2 TLSv1.1" key-managers="ServerKeyManager" trust-managers="CaTrustManager"
+            <server-ssl-context name="ServerSslContextNoAuth" key-manager="ServerKeyManager" trust-manager="CaTrustManager"/>
+            <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1.3 TLSv1.2 TLSv1.1" key-manager="ServerKeyManager" trust-manager="CaTrustManager"
                                 want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false"
                                 providers="ManagerProviderLoader" provider-name="SunJSSE" session-timeout="321" maximum-session-cache-size="123"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
-            <client-ssl-context name="ClientSslContextNoAuth" trust-managers="CaTrustManager" />
-            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextNoAuth" trust-manager="CaTrustManager" />
+            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-manager="ClientKeyManager" trust-manager="CaTrustManager" providers="ManagerProviderLoader"/>
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
@@ -66,11 +66,12 @@
         <server-ssl-contexts>
             <server-ssl-context name="ServerSslContextNoAuth" key-managers="ServerKeyManager" trust-managers="CaTrustManager"/>
             <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1.3 TLSv1.2 TLSv1.1" key-managers="ServerKeyManager" trust-managers="CaTrustManager"
-                                want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false" providers="ManagerProviderLoader" provider-name="SunJSSE"/>
+                                want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false"
+                                providers="ManagerProviderLoader" provider-name="SunJSSE" session-timeout="321" maximum-session-cache-size="123"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="ClientSslContextNoAuth" trust-managers="CaTrustManager" />
-            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" use-cipher-suites-order="false" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" providers="ManagerProviderLoader"/>
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -46,7 +46,7 @@
                 session-timeout="120" wrap="false" key-managers="serverKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
         </server-ssl-contexts>
         <client-ssl-contexts>
-            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" use-cipher-suites-order="true" key-managers="clientKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
+            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-managers="clientKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
         </client-ssl-contexts>
     </tls>
     <credential-stores>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -43,10 +43,10 @@
         </trust-managers>
         <server-ssl-contexts>
             <server-ssl-context name="server" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true" use-cipher-suites-order="false" maximum-session-cache-size="10"
-                session-timeout="120" wrap="false" key-managers="serverKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
+                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" providers="custom-loader" provider-name="first" />
         </server-ssl-contexts>
         <client-ssl-contexts>
-            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-managers="clientKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
+            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader" provider-name="first" />
         </client-ssl-contexts>
     </tls>
     <credential-stores>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
-        <version.org.wildfly.build-tools>1.1.8.Final</version.org.wildfly.build-tools>
+        <version.org.wildfly.build-tools>1.2.2.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.0.Beta4</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.2.0.Beta10</version.org.wildfly.common>

--- a/server/src/main/java/org/jboss/as/server/deployment/SimpleAttachable.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SimpleAttachable.java
@@ -22,12 +22,12 @@
 
 package org.jboss.as.server.deployment;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.wildfly.common.Assert;
 
@@ -98,7 +98,7 @@ public class SimpleAttachable implements Attachable {
         }
     }
 
-    public synchronized Collection<AttachmentKey<?>> attachmentKeys() {
+    public synchronized Set<AttachmentKey<?>> attachmentKeys() {
         return new HashSet<AttachmentKey<?>>(attachments.keySet());
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CdTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CdTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.management.cli;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,6 +57,29 @@ public class CdTestCase {
             Assert.fail("Can't cd into a non-existing nodepath.");
         } catch(CommandLineException e) {
             // expected
+        } finally {
+            ctx.terminateSession();
+        }
+    }
+
+    @Test
+    public void testNoValidation() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext();
+        try {
+            ctx.connectController();
+            ctx.handle("cd /subsystem=subsystem --no-validation");
+            DefaultOperationRequestAddress address = new DefaultOperationRequestAddress();
+            address.toNode("subsystem", "subsystem");
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeName(),
+                    address.getNodeName(), ctx.getCurrentNodePath().getNodeName());
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeType(),
+                    address.getNodeType(), ctx.getCurrentNodePath().getNodeType());
+
+            ctx.handle("cd --no-validation /subsystem=subsystem");
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeName(),
+                    address.getNodeName(), ctx.getCurrentNodePath().getNodeName());
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeType(),
+                    address.getNodeType(), ctx.getCurrentNodePath().getNodeType());
         } finally {
             ctx.terminateSession();
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2671
https://issues.jboss.org/browse/JBEAP-10328

Need to be merged in coordination with https://github.com/wildfly-security-incubator/wildfly/pull/205

* key/trust-managers capability changed to key/trust-manager (no array) for simple wrapping/reloading
* added operation  key-manager:init()