### PR TITLE
[WFCORE-2547][JBEAP-9628] null principal handling fix

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/capabilities/PrincipalTransformer.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/capabilities/PrincipalTransformer.java
@@ -48,7 +48,7 @@ public interface PrincipalTransformer extends Function<Principal, Principal> {
             if (principal == null) return null;
             for (PrincipalTransformer transformer : clone) {
                 Principal transformed = transformer.apply(principal);
-                if (transformed != null) {
+                if (transformed != null && transformed.getName() != null) {
                     return transformed;
                 }
             }


### PR DESCRIPTION
Fixed aggregate-principal-transformer to work corectly with NamePrincipal(null).

need to be merged together with https://github.com/wildfly-security/wildfly-elytron/pull/798

Kabir: Part of https://issues.jboss.org/browse/JBEAP-9628