### PR TITLE
[WFCORE-2730] allow empty target-name and action in permission 

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -108,12 +108,12 @@ class PermissionMapperDefinitions {
 
     static final SimpleAttributeDefinition TARGET_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.TARGET_NAME, ModelType.STRING, true)
             .setAllowExpression(true)
-            .setMinSize(1)
+            .setMinSize(0)
             .build();
 
     static final SimpleAttributeDefinition ACTION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ACTION, ModelType.STRING, true)
             .setAllowExpression(true)
-            .setMinSize(1)
+            .setMinSize(0)
             .build();
 
     static final ObjectTypeAttributeDefinition PERMISSION = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.PERMISSION, CLASS_NAME, MODULE, TARGET_NAME, ACTION)


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2730

For some purposes there is need to construct permission with blank string as param (name/action) - for example WebResourcePermission.