### PR TITLE
[WFCORE-2814] There is description of "case-sensitive" attribute inconsistency between model and XSD.

### DIFF
--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -4740,10 +4740,10 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="case-sensitive" type="xs:boolean" use="optional">
+        <xs:attribute name="case-sensitive" type="xs:boolean" use="optional" default="false">
             <xs:annotation>
                 <xs:documentation>
-                    Indicates that the credential store is case sensitive and should then allow for upper case in alias.
+                    Case sensitivity of the credential store. If case insensitive only lower case names are allowed for aliases.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-2814
JBEAP: https://issues.jboss.org/browse/JBEAP-10619
