### PR TITLE
[WFCORE-2746] Move some elytron tests add support for -Delytron

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -51,6 +51,8 @@
         <xslt.scripts.dir>${basedir}/../src/test/xslt</xslt.scripts.dir>
         <enforcer.skip>true</enforcer.skip>
         <jbossas.ts.dir>${basedir}/..</jbossas.ts.dir>
+
+        <ts.elytron.cli>../shared/enable-elytron.cli</ts.elytron.cli>
     </properties>
 
     <!--
@@ -78,6 +80,11 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-feature-pack</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-vault-test-feature-pack</artifactId>
             <type>zip</type>
         </dependency>
 
@@ -199,6 +206,7 @@
                          <include>org/jboss/as/test/integration/domain/suspendresume/*TestCase.java</include>
                          <include>org/jboss/as/test/integration/domain/slavereconnect/*TestCase.java</include>
                          <include>org/jboss/as/test/integration/domain/management/*TestCase.java</include>
+                         <include>org/jboss/as/test/integration/domain/elytron/*TestCase.java</include>
                     </includes>
                 </configuration>
             </plugin>
@@ -265,6 +273,48 @@
                 </plugins>
             </build>
         </profile>
-    </profiles>
+
+        <!-- profile to configure WildFly to use Elytron instead of legacy security: -Delytron -->
+        <profile>
+            <id>elytron.profile</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+                <file>
+                    <exists>${ts.elytron.cli}</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <offline>true</offline>
+                            <scripts>
+                                <script>${ts.elytron.cli}</script>
+                            </scripts>
+                            <jboss-home>${project.build.directory}/wildfly-core</jboss-home>
+                            <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                            <system-properties>
+                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                <module.path>${jboss.dist}/modules</module.path>
+                            </system-properties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+      </profiles>
 
 </project>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AbstractSlaveHCAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AbstractSlaveHCAuthenticationTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADMIN_ONLY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_STATE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SECRET;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SECURITY_REALM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_IDENTITY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ * Encapsulates some of the logic for tests where a slave host controller attempts to authenticate to master controller.
+ */
+public abstract class AbstractSlaveHCAuthenticationTestCase {
+
+    private static final int TIMEOUT = 60000;
+
+    protected abstract ModelControllerClient getDomainMasterClient();
+    protected abstract ModelControllerClient getDomainSlaveClient();
+
+    protected void reloadSlave() throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set("reload");
+        op.get(OP_ADDR).add(HOST, "slave");
+        op.get(ADMIN_ONLY).set(false);
+        try {
+            getDomainSlaveClient().execute(new OperationBuilder(op).build());
+        } catch(IOException e) {
+            final Throwable cause = e.getCause();
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
+                throw e;
+            } // else ignore, this might happen if the channel gets closed before we got the response
+        }
+        // use testSupport.getDomainSlaveLifecycleUtil().awaitHostController(System.currentTimeMillis());
+        // in the subclass waiting to know when the slaveHC is available before continuing.
+    }
+
+    protected void readHostControllerStatus(ModelControllerClient client) throws Exception {
+        if (!lookupHostInModel(client))
+            Assert.fail("Cannot validate host 'slave' is running");
+    }
+
+    protected boolean lookupHostInModel(ModelControllerClient client) throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).add(HOST, "slave");
+        operation.get(NAME).set(HOST_STATE);
+
+        try {
+            final ModelNode result = client.execute(operation);
+            if (result.get(OUTCOME).asString().equals(SUCCESS)){
+                final ModelNode model = result.require(RESULT);
+                if (model.asString().equalsIgnoreCase("running")) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            //
+        }
+
+        return false;
+    }
+
+    protected void setSlaveSecret(String value) throws IOException {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        op.get(OP_ADDR).add(HOST, "slave").add(CORE_SERVICE, MANAGEMENT).add(SECURITY_REALM, "ManagementRealm").add(SERVER_IDENTITY, SECRET);
+        op.get(NAME).set(VALUE);
+        op.get(VALUE).set(value);
+        getDomainSlaveClient().execute(new OperationBuilder(op).build());
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveHostControllerAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveHostControllerAuthenticationTestCase.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT_OPTIONS;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.test.integration.domain.management.util.Authentication;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.test.security.VaultHandler;
+
+/**
+ * Test a slave HC connecting to the domain using all 3 valid ways of configuring the slave HC's credential:
+ * Base64 encoded password, system-property-backed expression, and vault expression.
+ *
+ * @author Brian Stansberry (c) 2013 Red Hat Inc.
+ */
+public class SlaveHostControllerAuthenticationTestCase extends AbstractSlaveHCAuthenticationTestCase {
+
+    private static final String VAULT_BLOCK = "ds_TestDS";
+    private static final String RIGHT_PASSWORD = DomainLifecycleUtil.SLAVE_HOST_PASSWORD;
+
+    private static ModelControllerClient domainMasterClient;
+    private static ModelControllerClient domainSlaveClient;
+    private static DomainTestSupport testSupport;
+
+    static final String RESOURCE_LOCATION = SlaveHostControllerAuthenticationTestCase.class.getProtectionDomain().getCodeSource().getLocation().getFile()
+            + "vault-shcatc/";
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+
+        // Set up a domain with a master that doesn't support local auth so slaves have to use configured credentials
+        testSupport = DomainTestSupport.create(
+                DomainTestSupport.Configuration.create(SlaveHostControllerAuthenticationTestCase.class.getSimpleName(),
+                        "domain-configs/domain-standard.xml",
+                        "host-configs/host-master-no-local.xml", "host-configs/host-secrets.xml"));
+
+        // Tweak the callback handler so the master test driver client can authenticate
+        // To keep setup simple it uses the same credentials as the slave host
+        WildFlyManagedConfiguration masterConfig = testSupport.getDomainMasterConfiguration();
+        CallbackHandler callbackHandler = Authentication.getCallbackHandler("slave", RIGHT_PASSWORD, "ManagementRealm");
+        masterConfig.setCallbackHandler(callbackHandler);
+
+        testSupport.start();
+
+        domainMasterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        domainSlaveClient = testSupport.getDomainSlaveLifecycleUtil().getDomainClient();
+
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport.stop();
+        testSupport = null;
+        domainMasterClient = null;
+        domainSlaveClient = null;
+    }
+
+    @Test
+    public void testSlaveRegistration() throws Exception {
+        slaveWithBase64PasswordTest();
+        slaveWithSystemPropertyPasswordTest();
+        slaveWithVaultPasswordTest();
+    }
+
+    private void slaveWithBase64PasswordTest() throws Exception {
+        // Simply check that the initial startup produced a registered slave
+        readHostControllerStatus(domainMasterClient);
+    }
+
+    private void slaveWithSystemPropertyPasswordTest() throws Exception {
+
+        // Set the slave secret to a system-property-backed expression
+        setSlaveSecret("${slave.secret:" + RIGHT_PASSWORD + "}");
+
+        reloadSlave();
+        testSupport.getDomainSlaveLifecycleUtil().awaitHostController(System.currentTimeMillis());
+        // Validate that it joined the master
+        readHostControllerStatus(domainMasterClient);
+    }
+
+    private void slaveWithVaultPasswordTest() throws Exception {
+
+        VaultHandler.cleanFilesystem(RESOURCE_LOCATION, true);
+
+        // create new vault
+        VaultHandler vaultHandler = new VaultHandler(RESOURCE_LOCATION);
+
+        try {
+
+            // create security attributes
+            String attributeName = "value";
+            String vaultPasswordString = vaultHandler.addSecuredAttribute(VAULT_BLOCK, attributeName,
+                    RIGHT_PASSWORD.toCharArray());
+
+            // create new vault setting in host
+            ModelNode op = new ModelNode();
+            op.get(OP).set(ADD);
+            op.get(OP_ADDR).add(HOST, "slave").add(CORE_SERVICE, VAULT);
+            ModelNode vaultOption = op.get(VAULT_OPTIONS);
+            vaultOption.get("KEYSTORE_URL").set(vaultHandler.getKeyStore());
+            vaultOption.get("KEYSTORE_PASSWORD").set(vaultHandler.getMaskedKeyStorePassword());
+            vaultOption.get("KEYSTORE_ALIAS").set(vaultHandler.getAlias());
+            vaultOption.get("SALT").set(vaultHandler.getSalt());
+            vaultOption.get("ITERATION_COUNT").set(vaultHandler.getIterationCountAsString());
+            vaultOption.get("ENC_FILE_DIR").set(vaultHandler.getEncodedVaultFileDirectory());
+            domainSlaveClient.execute(new OperationBuilder(op).build());
+
+            setSlaveSecret("${" + vaultPasswordString + "}");
+
+            reloadSlave();
+
+            testSupport.getDomainSlaveLifecycleUtil().awaitHostController(System.currentTimeMillis());
+            // Validate that it joined the master
+            readHostControllerStatus(domainMasterClient);
+        } finally {
+            // remove temporary files
+            vaultHandler.cleanUp();
+        }
+    }
+
+    @Override
+    protected ModelControllerClient getDomainMasterClient() {
+        return domainMasterClient;
+    }
+
+    @Override
+    protected ModelControllerClient getDomainSlaveClient() {
+        return domainSlaveClient;
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SlaveHostControllerElytronAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/elytron/SlaveHostControllerElytronAuthenticationTestCase.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.elytron;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADMIN_ONLY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SASL_AUTHENTICATION_FACTORY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import javax.security.auth.callback.CallbackHandler;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.domain.AbstractSlaveHCAuthenticationTestCase;
+import org.jboss.as.test.integration.domain.management.util.Authentication;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test a slave HC connecting to the domain Elytron authentication context.
+ */
+public class SlaveHostControllerElytronAuthenticationTestCase extends AbstractSlaveHCAuthenticationTestCase {
+
+    protected static final String RIGHT_PASSWORD = DomainLifecycleUtil.SLAVE_HOST_PASSWORD;
+
+    private static ModelControllerClient domainMasterClient;
+    private static ModelControllerClient domainSlaveClient;
+    private static DomainTestSupport testSupport;
+
+    private final String BAD_PASSWORD = "bad_password";
+    private final int FAILED_RELOAD_TIMEOUT_MILLIS = 10_000;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        // Set up a domain with a master that doesn't support local auth so slaves have to use configured credentials
+        testSupport = DomainTestSupport.create(
+                DomainTestSupport.Configuration.create(SlaveHostControllerElytronAuthenticationTestCase.class.getSimpleName(),
+                        "domain-configs/domain-minimal.xml",
+                        "host-configs/host-master-elytron.xml", "host-configs/host-slave-elytron.xml"));
+
+        // Tweak the callback handler so the master test driver client can authenticate
+        // To keep setup simple it uses the same credentials as the slave host
+        WildFlyManagedConfiguration masterConfig = testSupport.getDomainMasterConfiguration();
+        CallbackHandler callbackHandler = Authentication.getCallbackHandler("slave", RIGHT_PASSWORD, "ManagementRealm");
+        masterConfig.setCallbackHandler(callbackHandler);
+
+        testSupport.start();
+
+        domainMasterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        domainSlaveClient = testSupport.getDomainSlaveLifecycleUtil().getDomainClient();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport.stop();
+        testSupport = null;
+        domainMasterClient = null;
+        domainSlaveClient = null;
+    }
+
+    @Override
+    protected ModelControllerClient getDomainMasterClient() {
+        return domainMasterClient;
+    }
+
+    @Override
+    protected ModelControllerClient getDomainSlaveClient() {
+        return domainSlaveClient;
+    }
+
+    @Test
+    public void testSlaveRegistration() throws Exception {
+        slaveWithDigestM5Mechanism();
+        // TODO WFLY-8630 restore this
+        //slaveWithPlainMechanism();
+        slaveWithInvalidPassword();
+    }
+
+    private void slaveWithDigestM5Mechanism() throws Exception {
+        // Simply check that the initial startup produced a registered slave
+        readHostControllerStatus(getDomainMasterClient());
+    }
+
+    private void slaveWithPlainMechanism() throws Exception {
+        // Set the allowed mechanism to PLAIN
+        getDomainMasterClient().execute(changePresentedMechanisms("master", new HashSet<>(Arrays.asList("PLAIN"))));
+        getDomainSlaveClient().execute(changeSaslMechanism("slave", "PLAIN"));
+
+        // Reload the slave and check that it produces a registered slave
+        reloadSlave();
+        readHostControllerStatus(getDomainMasterClient());
+
+        // Set the allowed mechanism back to Digest-MD5
+        getDomainMasterClient().execute(changePresentedMechanisms("master", new HashSet<>(Arrays.asList("DIGEST-MD5"))));
+        getDomainSlaveClient().execute(changeSaslMechanism("slave", "DIGEST-MD5"));
+        reloadSlave();
+        testSupport.getDomainSlaveLifecycleUtil().awaitHostController(System.currentTimeMillis());
+        readHostControllerStatus(domainMasterClient);
+    }
+
+    /**
+     * Since this test results in an invalid configuration of a host, it needs to be run last in the test sequence.
+     *
+     * @throws Exception
+     */
+    private void slaveWithInvalidPassword() throws Exception {
+        // Set up a bad password
+        getDomainSlaveClient().execute(changePassword(BAD_PASSWORD));
+
+        // Reload the slave, after being reloaded, the slave should fail because it won't be able to connect to master
+        reloadWithoutChecks();
+
+        // Verify that the slave host is not running
+        Assert.assertFalse("Host \"slave\" has connected to master even though it has bad password",
+                hostRunning(FAILED_RELOAD_TIMEOUT_MILLIS));
+
+        // Note that the slave is now lost to us - we can't configure it via master
+    }
+
+    private ModelNode changeSaslMechanism(String slaveName, String mechanism) {
+        ModelNode setAllowedMechanism = new ModelNode();
+        setAllowedMechanism.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        setAllowedMechanism.get(OP_ADDR).set(
+                new ModelNode().add(HOST, slaveName).add(SUBSYSTEM, "elytron")
+                        .add("authentication-configuration", "slaveHostAConfiguration"));
+        setAllowedMechanism.get(NAME).set("allow-sasl-mechanisms");
+        setAllowedMechanism.get(VALUE).set(new ModelNode().add(mechanism));
+
+        return setAllowedMechanism;
+    }
+
+    private ModelNode changePresentedMechanisms(String slaveName, Set<String> mechanisms) {
+        ModelNode setPresentedMechanisms = new ModelNode();
+        setPresentedMechanisms.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        setPresentedMechanisms.get(OP_ADDR).set(
+                new ModelNode().add(HOST, slaveName).add(SUBSYSTEM, "elytron")
+                        .add(SASL_AUTHENTICATION_FACTORY, "management-sasl-authentication"));
+        setPresentedMechanisms.get(NAME).set("mechanism-configurations");
+
+        ModelNode allMechanismsNode = new ModelNode();
+
+        for (String mechanism : mechanisms) {
+            ModelNode mechanismNode = new ModelNode();
+            mechanismNode.get("mechanism-name").set(mechanism);
+            if (mechanism.equals("LOCAL-JBOSS-USER")) {
+                mechanismNode.get("realm-mapper").set("local");
+            } else {
+                mechanismNode.get("mechanism-realm-configurations").set(new ModelNode().get("realm-name").set("ManagementRealm"));
+            }
+
+            allMechanismsNode.add(mechanismNode);
+        }
+
+        setPresentedMechanisms.get(VALUE).set(allMechanismsNode);
+
+        return setPresentedMechanisms;
+    }
+
+    private ModelNode changePassword(String password) {
+        ModelNode setPassword = new ModelNode();
+        setPassword.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        setPassword.get(OP_ADDR).set(
+                new ModelNode().add(HOST, "slave").add(SUBSYSTEM, "elytron")
+                        .add("authentication-configuration", "slaveHostAConfiguration"));
+        setPassword.get(NAME).set("credential-reference.clear-text");
+        setPassword.get(VALUE).set(password);
+
+        return setPassword;
+    }
+
+    private void reloadWithoutChecks() throws IOException {
+        ModelNode reloadSlave = new ModelNode();
+        reloadSlave.get(OP).set("reload");
+        reloadSlave.get(OP_ADDR).add(HOST, "slave");
+        reloadSlave.get(ADMIN_ONLY).set(false);
+        try {
+            getDomainSlaveClient().execute(reloadSlave);
+        } catch(IOException e) {
+            final Throwable cause = e.getCause();
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
+                throw e;
+            } // else ignore, this might happen if the channel gets closed before we got the response
+        }
+    }
+
+    private boolean hostRunning(long timeout) throws Exception {
+        final long time = System.currentTimeMillis() + timeout;
+        do {
+            Thread.sleep(250);
+            if (lookupHostInModel(getDomainMasterClient())) {
+                return true;
+            }
+        } while (System.currentTimeMillis() < time);
+
+        return false;
+    }
+}

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,0 +1,168 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<host xmlns="urn:jboss:domain:5.0" name="master">
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.wildfly.extension.core-management"/>
+        <extension module="org.wildfly.extension.elytron"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <!-- removed although management realms should not be referenced at all -->
+                    <!--<local default-user="$local" skip-group-loading="true"/>-->
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <server-identities>
+                    <ssl>
+                        <keystore path="application.keystore" relative-to="jboss.domain.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
+                    </ssl>
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.domain.data.dir"/>
+                <file-handler name="server-file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="${jboss.management.native.port:9999}"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true"/>
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+    <domain-controller>
+        <local/>
+    </domain-controller>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.master.address}"/>
+        </interface>
+    </interfaces>
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="256m"/>
+            <jvm-options>
+                <option value="-server"/>
+                <option value="-XX:MetaspaceSize=96m"/>
+                <option value="-XX:MaxMetaspaceSize=256m"/>
+            </jvm-options>
+        </jvm>
+    </jvms>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:1.0" initial-providers="combined-providers">
+            <providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+            </providers>
+            <audit-logging>
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.domain.log.dir" format="JSON"/>
+            </audit-logging>
+            <security-domains>
+                <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper" security-event-listener="local-audit">
+                    <realm name="ManagementRealm" role-decoder="groups-to-roles"/>
+                    <!-- This shouldn't be used, but just to be sure -->
+                    <!--<realm name="local" role-mapper="super-user-mapper"/>-->
+                </security-domain>
+            </security-domains>
+            <security-realms>
+                <!-- This shouldn't be used, but just to be sure -->
+                <!--<identity-realm name="local" identity="$local"/>-->
+                <properties-realm name="ManagementRealm">
+                    <users-properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" digest-realm-name="ManagementRealm"/>
+                    <groups-properties path="mgmt-groups.properties" relative-to="jboss.domain.config.dir"/>
+                </properties-realm>
+            </security-realms>
+            <mappers>
+                <constant-permission-mapper name="default-permission-mapper">
+                    <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
+                </constant-permission-mapper>
+                <constant-realm-mapper name="local" realm-name="local"/>
+                <simple-role-decoder name="groups-to-roles" attribute="groups"/>
+                <constant-role-mapper name="super-user-mapper">
+                    <role name="SuperUser"/>
+                </constant-role-mapper>
+            </mappers>
+            <http>
+                <http-authentication-factory name="management-http-authentication" http-server-mechanism-factory="global" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="BASIC">
+                            <mechanism-realm realm-name="Management Realm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <provider-http-server-mechanism-factory name="global"/>
+            </http>
+            <sasl>
+                <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <provider-sasl-server-factory name="global"/>
+                <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                    <filters>
+                        <filter provider-name="WildFlyElytron"/>
+                    </filters>
+                </mechanism-provider-filtering-sasl-server-factory>
+                <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
+                    <filters>
+                        <filter>
+                            <pattern-filter value="JBOSS-LOCAL-USER"/>
+                        </filter>
+                        <filter>
+                            <pattern-filter value="DIGEST-MD5"/>
+                        </filter>
+                    </filters>
+                    <properties>
+                        <property name="wildfly.sasl.local-user.default-user" value="$local"/>
+                    </properties>
+                </configurable-sasl-server-factory>
+            </sasl>
+        </subsystem>
+    </profile>
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -1,0 +1,72 @@
+<!--
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<host xmlns="urn:jboss:domain:5.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
+      name="slave">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                    <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true" />
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="19999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="19990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm"/>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+        </jvm>
+    </jvms>
+
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<host xmlns="urn:jboss:domain:5.0" name="slave">
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.wildfly.extension.core-management"/>
+        <extension module="org.wildfly.extension.elytron"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                    <!-- Replace this with either a base64 password of your own, or use a vault with a vault expression -->
+                    <secret value="c2xhdmVfdXNlcl9wYXNzd29yZA=="/>
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <server-identities>
+                    <ssl>
+                        <keystore path="application.keystore" relative-to="jboss.domain.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
+                    </ssl>
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.domain.data.dir"/>
+                <file-handler name="server-file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="${jboss.management.native.port:19999}"/>
+            </native-interface>
+        </management-interfaces>
+    </management>
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" authentication-context="slaveHostAContext"/>
+    </domain-controller>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="256m"/>
+            <jvm-options>
+                <option value="-server"/>
+                <option value="-XX:MetaspaceSize=96m"/>
+                <option value="-XX:MaxMetaspaceSize=256m"/>
+            </jvm-options>
+        </jvm>
+    </jvms>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:1.0" initial-providers="combined-providers">
+            <authentication-client>
+                <authentication-configuration allow-sasl-mechanisms="DIGEST-MD5" name="slaveHostAConfiguration" authentication-name="slave" realm="ManagementRealm">
+                    <credential-reference clear-text="slave_us3r_password"/>
+                </authentication-configuration>
+                <authentication-context name="slaveHostAContext">
+                    <match-rule match-host="${jboss.test.host.master.address}" authentication-configuration="slaveHostAConfiguration"/>
+                </authentication-context>
+            </authentication-client>
+            <providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+            </providers>
+            <audit-logging>
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.domain.log.dir" format="JSON"/>
+            </audit-logging>
+            <security-domains>
+                <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper" security-event-listener="local-audit">
+                    <realm name="ManagementRealm" role-decoder="groups-to-roles"/>
+                    <!-- This shouldn't be used, but just to be sure -->
+                    <!--<realm name="local" role-mapper="super-user-mapper"/>-->
+                </security-domain>
+            </security-domains>
+            <security-realms>
+                <!-- This shouldn't be used, but just to be sure -->
+                <!--<identity-realm name="local" identity="$local"/>-->
+                <properties-realm name="ManagementRealm">
+                    <users-properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" digest-realm-name="ManagementRealm"/>
+                    <groups-properties path="mgmt-groups.properties" relative-to="jboss.domain.config.dir"/>
+                </properties-realm>
+            </security-realms>
+            <mappers>
+                <constant-permission-mapper name="default-permission-mapper">
+                    <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
+                </constant-permission-mapper>
+                <constant-realm-mapper name="local" realm-name="local"/>
+                <simple-role-decoder name="groups-to-roles" attribute="groups"/>
+                <constant-role-mapper name="super-user-mapper">
+                    <role name="SuperUser"/>
+                </constant-role-mapper>
+            </mappers>
+            <http>
+                <http-authentication-factory name="management-http-authentication" http-server-mechanism-factory="global" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="BASIC">
+                            <mechanism-realm realm-name="Management Realm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <provider-http-server-mechanism-factory name="global"/>
+            </http>
+            <sasl>
+                <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <!-- This shouldn't be used, but just to be sure -->
+                        <!--<mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>-->
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <provider-sasl-server-factory name="global"/>
+                <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                    <filters>
+                        <filter provider-name="WildFlyElytron"/>
+                    </filters>
+                </mechanism-provider-filtering-sasl-server-factory>
+                <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
+                    <filters>
+                        <!--<filter>-->
+                            <!--<pattern-filter value="JBOSS-LOCAL-USER"/>-->
+                        <!--</filter>-->
+                        <filter>
+                            <pattern-filter value="DIGEST-MD5"/>
+                        </filter>
+                    </filters>
+                    <!--<properties>-->
+                        <!--<property name="wildfly.sasl.local-user.default-user" value="$local"/>-->
+                    <!--</properties>-->
+                </configurable-sasl-server-factory>
+            </sasl>
+        </subsystem>
+    </profile>
+</host>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -38,9 +38,15 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>-->
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+
+        <ts.elytron.cli>../shared/enable-elytron.cli</ts.elytron.cli>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-test-runner</artifactId>
@@ -219,6 +225,49 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- profile to configure WildFly to use Elytron instead of legacy security: -Delytron -->
+        <profile>
+            <id>elytron.profile</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+                <file>
+                    <exists>${ts.elytron.cli}</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <offline>true</offline>
+                            <scripts>
+                                <script>${ts.elytron.cli}</script>
+                            </scripts>
+                            <jboss-home>${project.build.directory}/wildfly-core</jboss-home>
+                            <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                            <system-properties>
+                                <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                <module.path>${jboss.dist}/modules</module.path>
+                            </system-properties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
 
     </profiles>
 </project>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/HttpMgmtInterfaceElytronAuthenticationTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/HttpMgmtInterfaceElytronAuthenticationTestCase.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.manualmode.mgmt.elytron;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Test for authentication through http-interface secured by Elytron http-authentication-factory.
+ *
+ * @author olukas
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class HttpMgmtInterfaceElytronAuthenticationTestCase {
+
+    private static final String PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY = "global";
+    private static final String MANAGEMENT_FILESYSTEM_NAME = "mgmt-filesystem-name";
+
+    private static File tempFolder;
+
+    private static final String USER = "user";
+    private static final String CORRECT_PASSWORD = "password";
+
+    private static String host;
+
+    @Inject
+    private static ServerController CONTROLLER;
+
+    public static void prepareServerConfiguration() throws Exception {
+        tempFolder = File.createTempFile("ely-" + HttpMgmtInterfaceElytronAuthenticationTestCase.class.getSimpleName(), "", null);
+        if (tempFolder.exists()) {
+            tempFolder.delete();
+            tempFolder.mkdir();
+        }
+        String fsRealmPath = tempFolder.getAbsolutePath() + File.separator + "fs-realm-users";
+
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            final String levelStr = "";
+            final List<String> roles = new ArrayList<>();
+
+            cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add(path=\"%s\", %s)", MANAGEMENT_FILESYSTEM_NAME, escapePath(fsRealmPath), levelStr));
+            cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s/identity=%s:add()", MANAGEMENT_FILESYSTEM_NAME, USER));
+            cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s/identity=%s:set-password(clear={password=\"%s\"})",
+                    MANAGEMENT_FILESYSTEM_NAME, USER, CORRECT_PASSWORD));
+            if (!roles.isEmpty()) {
+                cli.sendLine(String.format(
+                        "/subsystem=elytron/filesystem-realm=%s/identity=%s:add-attribute(name=groups, value=[%s])", MANAGEMENT_FILESYSTEM_NAME,
+                       USER, String.join(",", roles)));
+            }
+
+            cli.sendLine(String.format(
+                    "/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%1$s,role-decoder=groups-to-roles},{realm=local,role-mapper=super-user-mapper}],default-realm=%1$s,permission-mapper=default-permission-mapper)",
+                    MANAGEMENT_FILESYSTEM_NAME));
+            cli.sendLine(String.format(
+                    "/subsystem=elytron/http-authentication-factory=%1$s:add(http-server-mechanism-factory=%2$s,security-domain=%1$s,"
+                    + "mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=\"%1$s\"}]}])",
+                    MANAGEMENT_FILESYSTEM_NAME, PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY));
+            cli.sendLine(String.format(
+                    "/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=%s)",
+                    MANAGEMENT_FILESYSTEM_NAME));
+            cli.sendLine("reload");
+        }
+    }
+
+    public static void resetServerConfiguration() throws Exception {
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            FileUtils.deleteQuietly(tempFolder);
+            cli.sendLine(String.format(
+                    "/core-service=management/management-interface=http-interface:undefine-attribute(name=http-authentication-factory)",
+                    MANAGEMENT_FILESYSTEM_NAME));
+            cli.sendLine(String.format(
+                    "/subsystem=elytron/http-authentication-factory=%s:remove()",
+                    MANAGEMENT_FILESYSTEM_NAME, PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY));
+            cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()", MANAGEMENT_FILESYSTEM_NAME));
+            cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:remove()", MANAGEMENT_FILESYSTEM_NAME));
+        }
+        FileUtils.deleteDirectory(tempFolder);
+    }
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        CONTROLLER.start();
+        host = TestSuiteEnvironment.getServerAddress();
+        prepareServerConfiguration();
+    }
+
+    @AfterClass
+    public static void resetServer() throws Exception {
+        try {
+            resetServerConfiguration();
+        } finally {
+            CONTROLLER.stop();
+        }
+    }
+
+    /**
+     * Test whether existing user with correct password has granted access through http-interface secured by Elytron
+     * http-authentication-factory.
+     */
+    @Test
+    public void testCorrectUser() throws Exception {
+        CoreUtils.makeCallWithBasicAuthn(createSimpleManagementOperationUrl(), USER, CORRECT_PASSWORD, SC_OK);
+    }
+
+    /**
+     * Test whether existing user with wrong password has denied access through http-interface secured by Elytron
+     * http-authentication-factory.
+     */
+    @Test
+    public void testWrongPassword() throws Exception {
+        CoreUtils.makeCallWithBasicAuthn(createSimpleManagementOperationUrl(), USER, "wrongPassword", SC_UNAUTHORIZED);
+    }
+
+    /**
+     * Test whether existing user with empty password has denied access through http-interface secured by Elytron
+     * http-authentication-factory.
+     */
+    @Test
+    public void testEmptyPassword() throws Exception {
+        CoreUtils.makeCallWithBasicAuthn(createSimpleManagementOperationUrl(), USER, "", SC_UNAUTHORIZED);
+    }
+
+    /**
+     * Test whether non-existing user has denied access through http-interface secured by Elytron http-authentication-factory.
+     */
+    @Test
+    public void testWrongUser() throws Exception {
+        CoreUtils.makeCallWithBasicAuthn(createSimpleManagementOperationUrl(), "wrongUser", CORRECT_PASSWORD, SC_UNAUTHORIZED);
+    }
+
+    /**
+     * Test whether user with empty username has denied access through http-interface secured by Elytron
+     * http-authentication-factory.
+     */
+    @Test
+    public void testEmptyUser() throws Exception {
+        CoreUtils.makeCallWithBasicAuthn(createSimpleManagementOperationUrl(), "", CORRECT_PASSWORD, SC_UNAUTHORIZED);
+    }
+
+    private URL createSimpleManagementOperationUrl() throws URISyntaxException, IOException {
+        return new URL("http://" + host + ":9990/management?operation=attribute&name=server-state");
+    }
+
+    private static String escapePath(String path) {
+        // fix windows path escaping.
+        return path.replace("\\", "\\\\");
+    }
+}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -76,6 +76,8 @@
     <!-- Global testsuite system properties defaults. -->
 
     <properties>
+
+	<version.org.wildfly.plugin>1.2.0.Alpha4</version.org.wildfly.plugin>
         <!-- Current module's directory. Will automatically pick up sub-module's basedir. -->
         <jbossas.ts.submodule.dir>${basedir}</jbossas.ts.submodule.dir>
         <!-- Integration module's directory. To be overriden in sub-modules. -->

--- a/testsuite/shared/enable-elytron.cli
+++ b/testsuite/shared/enable-elytron.cli
@@ -1,0 +1,30 @@
+embed-server --server-config=standalone.xml
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+/core-service=management/security-realm=ManagementRealm:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+stop-embedded-server
+
+embed-host-controller
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/host=master/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/host=master/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/host=master/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+
+#/host=master/core-service=management/management-interface=native-interface:write-attribute(name=sasl-authentication-factory,value=management-sasl-authentication)
+#/host=master/core-service=management/management-interface=native-interface:undefine-attribute(name=security-realm)
+
+/host=master/core-service=management/security-realm=ManagementRealm:remove
+/host=master/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/host=master/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/host=master/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+stop-embedded-host-controller
+

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -93,6 +93,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractBaseSecurityRealmsServerSetupTask.java
@@ -1,26 +1,19 @@
 /*
+ * Copyright 2017 JBoss by Red Hat.
  *
- *  JBoss, Home of Professional Open Source.
- *  Copyright 2014, Red Hat, Inc., and individual contributors
- *  as indicated by the @author tags. See the copyright.txt file in the
- *  distribution for a full listing of individual contributors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation; either version 2.1 of
- *  the License, or (at your option) any later version.
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  This software is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- *  Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this software; if not, write to the Free
- *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
- * /
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.jboss.as.test.integration.security.common;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADVANCED_FILTER;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreAbstractSecurityDomainSetup.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreAbstractSecurityDomainSetup.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.security.common;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.integration.security.common.Constants.FLAG;
+import static org.jboss.as.test.integration.security.common.Constants.LOGIN_MODULE;
+import static org.jboss.as.test.integration.security.common.Constants.SECURITY_DOMAIN;
+
+/**
+ * @author Stuart Douglas
+ */
+public abstract class CoreAbstractSecurityDomainSetup implements ServerSetupTask {
+    private static final Logger LOGGER = Logger.getLogger(CoreAbstractSecurityDomainSetup.class);
+
+    protected static void applyUpdates(final ModelControllerClient client, final List<ModelNode> updates) {
+        for (ModelNode update : updates) {
+            try {
+                applyUpdate(client, update, false);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    protected static void applyUpdate(final ModelControllerClient client, ModelNode update, boolean allowFailure) throws IOException {
+        ModelNode result = client.execute(new OperationBuilder(update).build());
+        if (result.hasDefined("outcome") && (allowFailure || "success".equals(result.get("outcome").asString()))) {
+            if (result.hasDefined("result")) {
+                LOGGER.trace(result.get("result"));
+            }
+        } else if (result.hasDefined("failure-description")) {
+            throw new RuntimeException(result.get("failure-description").toString());
+        } else {
+            throw new RuntimeException("Operation not successful; outcome = " + result.get("outcome"));
+        }
+    }
+
+    @Override
+    public void tearDown(final ManagementClient managementClient) {
+
+        ModelNode op = new ModelNode();
+        op.get(OP).set(REMOVE);
+        op.get(OP_ADDR).add(SUBSYSTEM, "security");
+        op.get(OP_ADDR).add(SECURITY_DOMAIN, getSecurityDomainName());
+        // Don't rollback when the AS detects the war needs the module
+        op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+
+        try {
+            applyUpdate(managementClient.getControllerClient(), op, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected abstract String getSecurityDomainName();
+
+
+    protected void createSecurityDomain(final Class loginModuleClass, final Map<String, String> moduleOptionsCache, final ModelControllerClient client) {
+        final ModelNode compositeOp = new ModelNode();
+        compositeOp.get(OP).set(COMPOSITE);
+        compositeOp.get(OP_ADDR).setEmptyList();
+        ModelNode steps = compositeOp.get(STEPS);
+        PathAddress address = PathAddress.pathAddress()
+                .append(SUBSYSTEM, "security")
+                .append(SECURITY_DOMAIN, getSecurityDomainName());
+
+        steps.add(Util.createAddOperation(address));
+        address = address.append(Constants.AUTHENTICATION, Constants.CLASSIC);
+        steps.add(Util.createAddOperation(address));
+
+        ModelNode loginModule = Util.createAddOperation(address.append(LOGIN_MODULE, loginModuleClass.getName()));
+        loginModule.get(ModelDescriptionConstants.CODE).set(loginModuleClass.getName());
+        loginModule.get(FLAG).set("required");
+        loginModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+
+        ModelNode moduleOptions = loginModule.get("module-options");
+        for (Map.Entry<String, String> entry : moduleOptionsCache.entrySet()) {
+            moduleOptions.get(entry.getKey()).set(entry.getValue());
+        }
+        steps.add(loginModule);
+
+        try {
+            applyUpdates(client, Arrays.asList(compositeOp));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -27,6 +27,8 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+
+        <ts.elytron.cli>../shared/enable-elytron.cli</ts.elytron.cli>
     </properties>
 
     <dependencies>
@@ -145,5 +147,49 @@
             </plugin>
         </plugins>
     </build>
+
+     <profiles>
+         <!-- profile to configure WildFly to use Elytron instead of legacy security: -Delytron -->
+         <profile>
+             <id>elytron.profile</id>
+             <activation>
+                 <property>
+                     <name>elytron</name>
+                 </property>
+                 <file>
+                     <exists>${ts.elytron.cli}</exists>
+                 </file>
+             </activation>
+             <build>
+                 <plugins>
+                     <plugin>
+                         <groupId>org.wildfly.plugins</groupId>
+                         <artifactId>wildfly-maven-plugin</artifactId>
+                         <version>${version.org.wildfly.plugin}</version>
+                         <executions>
+                             <execution>
+                                 <phase>process-test-resources</phase>
+                                 <goals>
+                                     <goal>execute-commands</goal>
+                                 </goals>
+                             </execution>
+                         </executions>
+                         <configuration>
+                             <offline>true</offline>
+                             <scripts>
+                                 <script>${ts.elytron.cli}</script>
+                             </scripts>
+                             <jboss-home>${project.build.directory}/wildfly-core</jboss-home>
+                             <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                             <system-properties>
+                                 <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                 <module.path>${jboss.dist}/modules</module.path>
+                             </system-properties>
+                         </configuration>
+                     </plugin>
+                 </plugins>
+             </build>
+         </profile>
+      </profiles>
 
 </project>


### PR DESCRIPTION
WFCORE-2774 - move org.jboss.as.test.manualmode.mgmt.elytron.HttpMgmtInterfaceElytronAuthenticationTestCase to core
WFCORE-2749 - move AbstractSlaveHCAuthenticationTestCase
WFCORE-2774 move & remerge HttpMgmtInterfaceElytronAuthenticationTestCase from full to core
WFCORE-2746 - use wildfly mvn plugin

Approved here: https://github.com/wildfly/wildfly-core/pull/2378